### PR TITLE
Split lexer/tokens into their own (sub)packages.

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-# This will allow the linter to be installed.  All a mess.
-rm go.mod
-
 # Install tools to test our code-quality.
 go get -u golang.org/x/lint/golint
 go get -u honnef.co/go/tools/cmd/staticcheck
 
 # Run the static-check tool - we ignore errors in goserver/static.go
 t=$(mktemp)
-staticcheck -checks all ./... > $t
+staticcheck -checks all ./... | grep -v "no Go files in" > $t
 if [ -s $t ]; then
     echo "Found errors via 'staticcheck'"
     cat $t

--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -7,9 +7,6 @@ rm go.mod
 go get -u golang.org/x/lint/golint
 go get -u honnef.co/go/tools/cmd/staticcheck
 
-# Init the modules
-go mod init
-
 # Run the static-check tool - we ignore errors in goserver/static.go
 t=$(mktemp)
 staticcheck -checks all ./... > $t

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,7 +1,11 @@
-package evalfilter
+// Package lexer implements a simple lexer, which will parse
+// user-scripts to be executed by evalfilter.
+package lexer
 
 import (
 	"errors"
+
+	"github.com/skx/evalfilter/token"
 )
 
 // Lexer holds our object-state.
@@ -39,9 +43,9 @@ func (l *Lexer) readChar() {
 
 // NextToken will read the next token, skipping any white space, and ignoring
 // comments - which begin with `//`.
-func (l *Lexer) NextToken() Token {
+func (l *Lexer) NextToken() token.Token {
 
-	var tok Token
+	var tok token.Token
 	l.skipWhitespace()
 
 	// skip single-line comments
@@ -56,27 +60,27 @@ func (l *Lexer) NextToken() Token {
 		str, err := l.readString()
 
 		if err == nil {
-			tok.Type = STRING
+			tok.Type = token.STRING
 			tok.Literal = str
 		} else {
-			tok.Type = ILLEGAL
+			tok.Type = token.ILLEGAL
 			tok.Literal = err.Error()
 		}
 	case rune(0):
 		tok.Literal = ""
-		tok.Type = EOF
+		tok.Type = token.EOF
 	case rune(';'):
 		tok.Literal = ";"
-		tok.Type = SEMICOLON
+		tok.Type = token.SEMICOLON
 	case rune(','):
 		tok.Literal = ","
-		tok.Type = COMMA
+		tok.Type = token.COMMA
 	case rune('('):
 		tok.Literal = "("
-		tok.Type = LBRACKET
+		tok.Type = token.LBRACKET
 	case rune(')'):
 		tok.Literal = ")"
-		tok.Type = RBRACKET
+		tok.Type = token.RBRACKET
 	default:
 		if l.ch == '-' || isDigit(l.ch) {
 			return l.readDecimalNumber()
@@ -91,9 +95,9 @@ func (l *Lexer) NextToken() Token {
 		tok.Literal = l.readIdentifier()
 
 		if l.ch == '(' {
-			tok.Type = FUNCALL
+			tok.Type = token.FUNCALL
 		} else {
-			tok.Type = LookupIdentifier(tok.Literal)
+			tok.Type = token.LookupIdentifier(tok.Literal)
 		}
 		return tok
 	}
@@ -177,7 +181,7 @@ func (l *Lexer) readString() (string, error) {
 }
 
 // read a decimal / floating-point number
-func (l *Lexer) readDecimalNumber() Token {
+func (l *Lexer) readDecimalNumber() token.Token {
 
 	//
 	// Read an integer-number.
@@ -195,13 +199,13 @@ func (l *Lexer) readDecimalNumber() Token {
 		//
 		l.readChar()
 		fraction := l.readNumber()
-		return Token{Type: NUMBER, Literal: integer + "." + fraction}
+		return token.Token{Type: token.NUMBER, Literal: integer + "." + fraction}
 	}
 
 	//
 	// OK just an integer.
 	//
-	return Token{Type: NUMBER, Literal: integer}
+	return token.Token{Type: token.NUMBER, Literal: integer}
 }
 
 // read a numeric digit

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,7 +1,9 @@
-package evalfilter
+package lexer
 
 import (
 	"testing"
+
+	"github.com/skx/evalfilter/token"
 )
 
 // TestSomeStrings tests that the input of a pair of strings is tokenized
@@ -10,13 +12,13 @@ func TestSomeStrings(t *testing.T) {
 	input := `"Steve" , "Kemp"`
 
 	tests := []struct {
-		expectedType    Type
+		expectedType    token.Type
 		expectedLiteral string
 	}{
-		{STRING, "Steve"},
-		{COMMA, ","},
-		{STRING, "Kemp"},
-		{EOF, ""},
+		{token.STRING, "Steve"},
+		{token.COMMA, ","},
+		{token.STRING, "Kemp"},
+		{token.EOF, ""},
 	}
 	l := NewLexer(input)
 	for i, tt := range tests {
@@ -35,13 +37,13 @@ func TestStringEscape(t *testing.T) {
 	input := `"Steve\n\r\\" "Kemp\n\t\n" "Inline \"quotes\"."`
 
 	tests := []struct {
-		expectedType    Type
+		expectedType    token.Type
 		expectedLiteral string
 	}{
-		{STRING, "Steve\n\r\\"},
-		{STRING, "Kemp\n\t\n"},
-		{STRING, "Inline \"quotes\"."},
-		{EOF, ""},
+		{token.STRING, "Steve\n\r\\"},
+		{token.STRING, "Kemp\n\t\n"},
+		{token.STRING, "Inline \"quotes\"."},
+		{token.EOF, ""},
 	}
 	l := NewLexer(input)
 	for i, tt := range tests {
@@ -62,11 +64,11 @@ func TestComments(t *testing.T) {
 // This is another comment`
 
 	tests := []struct {
-		expectedType    Type
+		expectedType    token.Type
 		expectedLiteral string
 	}{
-		{STRING, "Steve"},
-		{EOF, ""},
+		{token.STRING, "Steve"},
+		{token.EOF, ""},
 	}
 	l := NewLexer(input)
 	for i, tt := range tests {
@@ -88,12 +90,12 @@ func TestUnterminatedString(t *testing.T) {
 print "Steve`
 
 	tests := []struct {
-		expectedType    Type
+		expectedType    token.Type
 		expectedLiteral string
 	}{
-		{PRINT, "print"},
-		{ILLEGAL, "unterminated string"},
-		{EOF, ""},
+		{token.PRINT, "print"},
+		{token.ILLEGAL, "unterminated string"},
+		{token.EOF, ""},
 	}
 	l := NewLexer(input)
 	for i, tt := range tests {
@@ -118,18 +120,18 @@ func TestNumber(t *testing.T) {
 34.54;
 `
 	tests := []struct {
-		expectedType    Type
+		expectedType    token.Type
 		expectedLiteral string
 	}{
-		{NUMBER, "1"},
-		{SEMICOLON, ";"},
-		{NUMBER, "-10"},
-		{SEMICOLON, ";"},
-		{NUMBER, "23"},
-		{SEMICOLON, ";"},
-		{NUMBER, "34.54"},
-		{SEMICOLON, ";"},
-		{EOF, ""},
+		{token.NUMBER, "1"},
+		{token.SEMICOLON, ";"},
+		{token.NUMBER, "-10"},
+		{token.SEMICOLON, ";"},
+		{token.NUMBER, "23"},
+		{token.SEMICOLON, ";"},
+		{token.NUMBER, "34.54"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
 	}
 	l := NewLexer(input)
 	for i, tt := range tests {
@@ -153,13 +155,13 @@ which continues";
 `
 
 	tests := []struct {
-		expectedType    Type
+		expectedType    token.Type
 		expectedLiteral string
 	}{
-		{PRINT, "print"},
-		{STRING, "This is a test which continues"},
-		{SEMICOLON, ";"},
-		{EOF, ""},
+		{token.PRINT, "print"},
+		{token.STRING, "This is a test which continues"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
 	}
 	l := NewLexer(input)
 	for i, tt := range tests {

--- a/token/token.go
+++ b/token/token.go
@@ -1,3 +1,5 @@
+// Package token holds the definitions of the various token-types
+// we require to lex our source code.
 package token
 
 // Type is a string

--- a/token/token.go
+++ b/token/token.go
@@ -1,4 +1,4 @@
-package evalfilter
+package token
 
 // Type is a string
 type Type string


### PR DESCRIPTION
This is mostly for clarity; the only changes made are the functional
ones required to make the compilation succeed.

This closes #10.