### PR TITLE
Moved functions over to a runtime package.

### DIFF
--- a/environment/env.go
+++ b/environment/env.go
@@ -1,0 +1,47 @@
+// Package environment contains a run-time environment for our
+// evaluation-engine.
+//
+// The environment contains any functions and variables which have
+// been set by the host application
+package environment
+
+// Environment is the runtime object which holds references
+// to functions/variables set by the host application.
+type Environment struct {
+
+	// Functions contains references to helper functions which
+	// have been made available to the user-script and which are
+	// implemented outside this package in the golang host-application.
+	Functions map[string]interface{}
+
+	// Variables contains references to variables set via
+	// the golang host-application.
+	Variables map[string]interface{}
+}
+
+// New creates a new (empty) environment.
+func New() *Environment {
+
+	// Create a stub object.
+	return &Environment{
+		Functions: make(map[string]interface{}),
+		Variables: make(map[string]interface{}),
+	}
+}
+
+// AddFunction adds a function to our runtime.
+//
+// Once a function has been added it may be used by the filter script.
+func (e *Environment) AddFunction(name string, fun interface{}) {
+	e.Functions[name] = fun
+}
+
+// SetVariable adds, or updates, a variable which will be available
+// to the filter script.
+//
+// Variables in the filter script should be prefixed with `$`,
+// for example a variable set as `time` will be accessed via the
+// name `$time`.
+func (e *Environment) SetVariable(name string, value interface{}) {
+	e.Variables[name] = value
+}

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,9 +1,11 @@
 package evalfilter
 
 import (
-	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/skx/evalfilter/environment"
+	"github.com/skx/evalfilter/runtime"
 )
 
 // TestLess tests uses `>` and `>=`.
@@ -195,7 +197,7 @@ func TestFunction(t *testing.T) {
 
 		obj := New(tst.Input)
 		obj.AddFunction("True",
-			func(eval *Evaluator, obj interface{}, args []Argument) interface{} {
+			func(env *environment.Environment, obj interface{}, args []runtime.Argument) interface{} {
 				return true
 			})
 
@@ -289,7 +291,6 @@ func TestParseErrors(t *testing.T) {
 
 	for _, tst := range tests {
 
-		fmt.Printf("Parsing: %s\n", tst)
 		obj := New(tst)
 		_, err := obj.Run(nil)
 

--- a/example_function_test.go
+++ b/example_function_test.go
@@ -1,6 +1,11 @@
 package evalfilter
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/skx/evalfilter/environment"
+	"github.com/skx/evalfilter/runtime"
+)
 
 // ExampleCustomFunction demonstrates how you can add a custom function
 // to your host-application, which is available to filter scripts.
@@ -62,7 +67,7 @@ return false;
 	// This is just an example :)
 	//
 	eval.AddFunction("length",
-		func(eval *Evaluator, obj interface{}, args []Argument) interface{} {
+		func(env *environment.Environment, obj interface{}, args []runtime.Argument) interface{} {
 
 			//
 			// Loop over the arguments
@@ -72,7 +77,7 @@ return false;
 				//
 				// Get the first argument.
 				//
-				val := arg.Value(eval, obj)
+				val := arg.Value(env, obj)
 
 				//
 				// Now as a string.

--- a/runtime/args.go
+++ b/runtime/args.go
@@ -1,4 +1,4 @@
-// The operations we allow users to implement use "Argument" as an
+// The operations we allow users to implement use "runtime.Argument" as an
 // abstract type.
 //
 // There are several types of arguments that we allow:
@@ -12,7 +12,6 @@
 // This file contains an abstract interface to define how those are
 // retrieved, as well as the concrete implementations.
 //
-
 package runtime
 
 import (

--- a/runtime/args.go
+++ b/runtime/args.go
@@ -1,7 +1,11 @@
-// The operations we allow users to implement use "runtime.Argument" as an
-// abstract type.
+// Package runtime defines the things that relate to our runtime, whether
+// that is the return-result from the parser, or the actual execution of
+// the operations.
 //
-// There are several types of arguments that we allow:
+// We allow a number of things to be handled at runtime.  The most important
+// is the handling of arguments, which are deferred to the interface
+// runtime.Argument.  The Argument type allows us to treat each of the
+// possible argument-types as generic:
 //
 // * Literal integers / strings / booleans.
 //

--- a/runtime/op.go
+++ b/runtime/op.go
@@ -1,7 +1,9 @@
 // Operation is the abstract interface any of our operations
 // must implement.
 
-package evalfilter
+package runtime
+
+import "github.com/skx/evalfilter/environment"
 
 // Operation is the abstract interface all operations much implement.
 type Operation interface {
@@ -15,5 +17,5 @@ type Operation interface {
 	//
 	//   error  - An error occurred
 	//
-	Run(self *Evaluator, obj interface{}) (bool, bool, error)
+	Run(env *environment.Environment, obj interface{}) (bool, bool, error)
 }

--- a/runtime/op_eval.go
+++ b/runtime/op_eval.go
@@ -9,7 +9,9 @@
 // The `foo` function call is evaluated and executed, via an instance of
 // this object.
 
-package evalfilter
+package runtime
+
+import "github.com/skx/evalfilter/environment"
 
 // EvalOperation holds state for the evaluation of a function-call.
 type EvalOperation struct {
@@ -19,9 +21,9 @@ type EvalOperation struct {
 }
 
 // Run runs the eval operation, the result is discarded.
-func (eo *EvalOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
+func (eo *EvalOperation) Run(env *environment.Environment, obj interface{}) (bool, bool, error) {
 
 	// Here we make the call, by evaluating the result.
-	eo.Value.(*FunctionArgument).Value(e, obj)
+	eo.Value.(*FunctionArgument).Value(env, obj)
 	return false, false, nil
 }

--- a/runtime/op_if.go
+++ b/runtime/op_if.go
@@ -1,11 +1,13 @@
 // This file contains the implementation for the `if` operation.
 
-package evalfilter
+package runtime
 
 import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/skx/evalfilter/environment"
 )
 
 // IfOperation holds state for the `if` operation
@@ -30,10 +32,10 @@ type IfOperation struct {
 }
 
 // Run executes an if statement.
-func (i *IfOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
+func (i *IfOperation) Run(env *environment.Environment, obj interface{}) (bool, bool, error) {
 
 	// Run the if-statement.
-	res, err := i.doesMatch(e, obj)
+	res, err := i.doesMatch(env, obj)
 
 	// Was there an error?
 	if err != nil {
@@ -57,7 +59,7 @@ func (i *IfOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
 			//
 			// If this was a return statement then we return
 			//
-			ret, val, err := t.Run(e, obj)
+			ret, val, err := t.Run(env, obj)
 			if ret {
 				return ret, val, err
 			}
@@ -76,7 +78,7 @@ func (i *IfOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
 			//
 			// If this was a return statement then we return
 			//
-			ret, val, err := t.Run(e, obj)
+			ret, val, err := t.Run(env, obj)
 			if ret {
 				return ret, val, err
 			}
@@ -89,12 +91,12 @@ func (i *IfOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
 }
 
 // doesMatch runs the actual comparison for the if-statement.
-func (i *IfOperation) doesMatch(e *Evaluator, obj interface{}) (bool, error) {
+func (i *IfOperation) doesMatch(env *environment.Environment, obj interface{}) (bool, error) {
 
 	//
 	// Expand the left & right sides of the conditional
 	//
-	lVal := i.Left.Value(e, obj)
+	lVal := i.Left.Value(env, obj)
 
 	//
 	// Single argument form?
@@ -112,7 +114,7 @@ func (i *IfOperation) doesMatch(e *Evaluator, obj interface{}) (bool, error) {
 		return false, nil
 	}
 
-	rVal := i.Right.Value(e, obj)
+	rVal := i.Right.Value(env, obj)
 
 	//
 	// Convert to strings, in case they're needed for the early

--- a/runtime/op_print.go
+++ b/runtime/op_print.go
@@ -1,8 +1,12 @@
 // This file contains the implementation for the print operation
 
-package evalfilter
+package runtime
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/skx/evalfilter/environment"
+)
 
 // PrintOperation holds state for the `print` operation.
 type PrintOperation struct {
@@ -11,9 +15,9 @@ type PrintOperation struct {
 }
 
 // Run runs the print operation.
-func (p *PrintOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
+func (p *PrintOperation) Run(env *environment.Environment, obj interface{}) (bool, bool, error) {
 	for _, val := range p.Values {
-		fmt.Printf("%v", val.Value(e, obj))
+		fmt.Printf("%v", val.Value(env, obj))
 	}
 	return false, false, nil
 }

--- a/runtime/op_return.go
+++ b/runtime/op_return.go
@@ -1,6 +1,8 @@
 // This file contains the implementation for the return operation
 
-package evalfilter
+package runtime
+
+import "github.com/skx/evalfilter/environment"
 
 // ReturnOperation holds state for the `return` operation
 type ReturnOperation struct {
@@ -9,6 +11,6 @@ type ReturnOperation struct {
 }
 
 // Run handles the return operation.
-func (r *ReturnOperation) Run(e *Evaluator, obj interface{}) (bool, bool, error) {
+func (r *ReturnOperation) Run(env *environment.Environment, obj interface{}) (bool, bool, error) {
 	return true, r.Value, nil
 }


### PR DESCRIPTION
We want to have a parser object in the future, which means that we need to share the functions we invoke between the parser and the actual evaluator.

That means moving them into a common package which both can use.

This updates #17.