### PR TITLE
Cli/evalfilter

### DIFF
--- a/cmd/evalfilter/lex_cmd.go
+++ b/cmd/evalfilter/lex_cmd.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/subcommands"
+	"github.com/skx/evalfilter/lexer"
+)
+
+//
+// The options set by our command-line flags: None
+//
+type lexCmd struct {
+}
+
+//
+// Glue
+//
+func (*lexCmd) Name() string     { return "lex" }
+func (*lexCmd) Synopsis() string { return "Show our lexer output." }
+func (*lexCmd) Usage() string {
+	return `lexer file1 file2 .. [fileN]:
+  Show the output from our lexer
+`
+}
+
+//
+// Flag setup
+//
+func (p *lexCmd) SetFlags(f *flag.FlagSet) {
+}
+
+func (p *lexCmd) Lex(file string) {
+	//
+
+	// Read the file contents.
+	//
+	dat, err := ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Printf("Error reading file %s - %s\n", file, err.Error())
+		return
+	}
+
+	//
+	// Create a lexer object with those contents.
+	//
+	l := lexer.New(string(dat))
+
+	//
+	// Dump the tokens.
+	//
+	for {
+		tok := l.NextToken()
+		fmt.Printf("%v\n", tok)
+		if tok.Type == "EOF" {
+			break
+		}
+	}
+}
+
+//
+// Entry-point.
+//
+func (p *lexCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+
+	//
+	// For each file we've been passed.
+	//
+	for _, file := range f.Args() {
+		p.Lex(file)
+	}
+
+	return subcommands.ExitSuccess
+
+}

--- a/cmd/evalfilter/on-call.json
+++ b/cmd/evalfilter/on-call.json
@@ -1,0 +1,4 @@
+{"Author":"Bot",
+ "Channel": "tech_alerts",
+ "Title": "",
+ "Message": "Database on Fire!"}

--- a/cmd/evalfilter/on-call.script
+++ b/cmd/evalfilter/on-call.script
@@ -1,0 +1,21 @@
+//
+// This is a simple on-call script.
+//
+
+
+if ( Channel !~ "_alerts" ) {
+    print("The channel is not important\n");
+    return false;
+}
+
+//
+// Ignore messages from Staff
+//
+if ( Author == "Alice" ) { return false; }
+if ( Author == "Bob" ) { return false; }
+if ( Author == "Chris" ) { return false; }
+if ( Author == "Diane" ) { return false; }
+
+
+print( "Raising alert!\n");
+return true;

--- a/cmd/evalfilter/run_cmd.go
+++ b/cmd/evalfilter/run_cmd.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/subcommands"
+	"github.com/skx/evalfilter"
+)
+
+//
+// The options set by our command-line flags.  A json file
+//
+type runCmd struct {
+
+	// The user may specify a JSON file.
+	jsonFile string
+}
+
+//
+// Glue
+//
+func (*runCmd) Name() string     { return "run" }
+func (*runCmd) Synopsis() string { return "Run a script file, against a JSON object." }
+func (*runCmd) Usage() string {
+	return `run -json=x.json script1 script2 .. [scriptN]:
+  Run the given file(s), using the object in the JSON-file as input.
+`
+}
+
+//
+// Flag setup
+//
+func (p *runCmd) SetFlags(f *flag.FlagSet) {
+	f.StringVar(&p.jsonFile, "json", "", "The JSON file, containing the object to test the script with.")
+
+}
+
+//
+// Run the given script.
+//
+func (p *runCmd) Run(file string) {
+
+	obj := make(map[string]interface{})
+	//
+	// If we have a JSON file then populate our object.
+	//
+	if p.jsonFile != "" {
+
+		//
+		// Read the file contents.
+		//
+		dat, err := ioutil.ReadFile(p.jsonFile)
+		if err != nil {
+			fmt.Printf("Error reading file %s - %s\n", p.jsonFile, err.Error())
+			return
+		}
+
+		//
+		// Parse the JSON
+		//
+		err = json.Unmarshal(dat, &obj)
+		if err != nil {
+			fmt.Printf("Error parsing JSON %s\n", err.Error())
+			return
+		}
+	}
+
+	//
+	// Read the file contents.
+	//
+	dat, err := ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Printf("Error reading file %s - %s\n", file, err.Error())
+		return
+	}
+
+	//
+	// Create the evaluator.
+	//
+	eval := evalfilter.New(string(dat))
+
+	//
+	// Run the script.
+	//
+	ret, err := eval.Run(obj)
+	if err != nil {
+		fmt.Printf("Failed to run script: %s\n", err.Error())
+		return
+	}
+
+	fmt.Printf("Script gave result %v\n", ret)
+}
+
+//
+// Entry-point.
+//
+func (p *runCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+
+	//
+	// For each file we've been passed; run it.
+	//
+	for _, file := range f.Args() {
+		p.Run(file)
+	}
+
+	return subcommands.ExitSuccess
+
+}

--- a/eval.go
+++ b/eval.go
@@ -603,8 +603,29 @@ func (e *Eval) evalIdentifier(node *ast.Identifier, env *object.Environment) obj
 	// Otherwise we need to perform a structure lookup.
 	//
 	if e.Object != nil {
+
 		ref := reflect.ValueOf(e.Object)
-		field := reflect.Indirect(ref).FieldByName(name)
+
+		//
+		// The field we find by reflection.
+		//
+		var field reflect.Value
+
+		//
+		// Are we dealing with a map?
+		//
+		if ref.Kind() == reflect.Map {
+			for _, key := range ref.MapKeys() {
+				if key.Interface() == name {
+
+					field = ref.MapIndex(key).Elem()
+					break
+				}
+			}
+		} else {
+
+			field = reflect.Indirect(ref).FieldByName(name)
+		}
 
 		switch field.Kind() {
 		case reflect.Int, reflect.Int64:


### PR DESCRIPTION
This pull-request updates our `cli/evalfilter` command-line application to allow you to pass a JSON-object and script to the evaluator, and see the output.

It is designed to allow debugging for example:

       ./evalfilter run -json on-call.json on-call.script

