### PR TITLE
Added parse-command and wired it up.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -176,8 +176,11 @@ func (bs *BlockStatement) TokenLiteral() string { return bs.Token.Literal }
 // String returns this object as a string.
 func (bs *BlockStatement) String() string {
 	var out bytes.Buffer
+
+	out.WriteString("\n{\n")
 	for _, s := range bs.Statements {
 		out.WriteString(s.String())
 	}
+	out.WriteString("\n}\n")
 	return out.String()
 }

--- a/ast/ast_call.go
+++ b/ast/ast_call.go
@@ -34,6 +34,6 @@ func (ce *CallExpression) String() string {
 	out.WriteString(ce.Function.String())
 	out.WriteString("(")
 	out.WriteString(strings.Join(args, ", "))
-	out.WriteString(")")
+	out.WriteString(");\n")
 	return out.String()
 }

--- a/ast/ast_string.go
+++ b/ast/ast_string.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/skx/evalfilter/token"
+import (
+	"strings"
+
+	"github.com/skx/evalfilter/token"
+)
 
 // StringLiteral holds a string
 type StringLiteral struct {
@@ -17,4 +21,9 @@ func (sl *StringLiteral) expressionNode() {}
 func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
 
 // String returns this object as a string.
-func (sl *StringLiteral) String() string { return sl.Token.Literal }
+func (sl *StringLiteral) String() string {
+	str := "\"" + sl.Token.Literal + "\""
+
+	str = strings.ReplaceAll(str, "\n", "\\n")
+	return str
+}

--- a/cmd/evalfilter/main.go
+++ b/cmd/evalfilter/main.go
@@ -28,6 +28,7 @@ func main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 	subcommands.Register(subcommands.CommandsCommand(), "")
 	subcommands.Register(&lexCmd{}, "")
+	subcommands.Register(&parseCmd{}, "")
 	subcommands.Register(&runCmd{}, "")
 
 	flag.Parse()

--- a/cmd/evalfilter/parse_cmd.go
+++ b/cmd/evalfilter/parse_cmd.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/subcommands"
+	"github.com/skx/evalfilter"
+)
+
+//
+// The options set by our command-line flags: None
+//
+type parseCmd struct {
+}
+
+//
+// Glue
+//
+func (*parseCmd) Name() string     { return "parse" }
+func (*parseCmd) Synopsis() string { return "Show our parser output." }
+func (*parseCmd) Usage() string {
+	return `parse file1 file2 .. [fileN]:
+  Show the output from our parser
+`
+}
+
+//
+// Flag setup
+//
+func (p *parseCmd) SetFlags(f *flag.FlagSet) {
+}
+
+
+// Parse parses the given file, and dumps the AST which
+// resulted from it.
+func (p *parseCmd) Parse(file string) {
+
+	//
+	// Read the file contents.
+	//
+	dat, err := ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Printf("Error reading file %s - %s\n", file, err.Error())
+		return
+	}
+
+	//
+	// Create the helper
+    //
+	eval := evalfilter.New(string(dat))
+
+	//
+	// Print the parsed program.
+	//
+	fmt.Printf("%s\n", eval.Program.String())
+}
+
+//
+// Entry-point.
+//
+func (p *parseCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+
+	//
+	// For each file we've been passed.
+	//
+	for _, file := range f.Args() {
+		p.Parse(file)
+	}
+
+	return subcommands.ExitSuccess
+
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/dvyukov/go-fuzz v0.0.0-20190919153955-532ac05586a1 // indirect
 	github.com/elazarl/go-bindata-assetfs v1.0.0 // indirect
+	github.com/google/subcommands v1.0.1
 	github.com/goruby/goruby v0.0.0-20190120152628-43c93d4f2611
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/pkg/errors v0.8.1 // indirect

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -306,7 +306,7 @@ func TestLine(t *testing.T) {
 			if found != line {
 				t.Fatalf("Invalid line number %d vs %d\n", line, l.GetLine())
 			}
-			line += 1
+			line++
 		}
 	}
 


### PR DESCRIPTION
This pull-request will close #29, by updating our `cmd/evalfilter` driver to allow dumping the state of a parsed program - i.e. dumping the AST.

This is useful to test broken-programs, and for those curious about implementations.