### PR TITLE
Fix parsing of AND & OR.

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -103,8 +103,17 @@ func (e *Eval) Run(obj interface{}) (bool, error) {
 	}
 
 	//
-	// Ok we ran, and returned a value, convert that
-	// to a boolean value.
+	// Is the return-value an error?  If so report that.
+	//
+	if out.Type() == object.ERROR_OBJ {
+		return false, fmt.Errorf("%s", out.Inspect())
+	}
+
+	//
+	// Otherwise we ran without any error, and returned
+	// a value.
+	//
+	// Convert that result to a boolean value.
 	//
 	return e.isTruthy(out), nil
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -505,3 +505,38 @@ func TestOperations(t *testing.T) {
 		}
 	}
 }
+
+// TestAndOr ensure that `and` + `or` work in the real world
+// https://github.com/skx/evalfilter/issues/31
+func TestAndOr(t *testing.T) {
+
+	// Test structure
+	type Params struct {
+		Origin  string
+		Country string
+		Value   int
+		Adults  int
+	}
+
+	// Instance of structure with known values
+	var d Params
+	d.Origin = "Mow"
+	d.Country = "RU"
+	d.Adults = 1
+	d.Value = 100
+
+	// Test-script
+	src := `(Origin == "MOW" || Country == "RU") && (Value > 100 || Adults == 1)`
+	obj := New(src)
+
+	// Run
+	ret, err := obj.Run(d)
+	if err != nil {
+		t.Fatalf("Found unexpected error running test - %s\n", err.Error())
+	}
+
+	if !ret {
+		t.Fatalf("Found unexpected result running script.")
+	}
+
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -24,6 +24,7 @@ const (
 	_ int = iota
 	LOWEST
 	ASSIGN // =
+	COND   // OR or AND
 	EQUALS // == or !=
 	CMP
 	LESSGREATER // > or <
@@ -53,8 +54,8 @@ var precedences = map[token.Type]int{
 	token.ASTERISK:  PRODUCT,
 	token.POW:       POWER,
 	token.MOD:       MOD,
-	token.AND:       CMP,
-	token.OR:        CMP,
+	token.AND:       COND,
+	token.OR:        COND,
 	token.LPAREN:    CALL,
 }
 


### PR DESCRIPTION
This pull request will close #31, by ensuring that we don't need extra/unexpected parenthesis around conditionals, when `&&` and `||` are used.