### PR TITLE
Add test-coverage for built-in functions.

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -81,6 +81,9 @@ const (
 	// Logical
 	OpAnd
 	OpOr
+
+	// Last opcode - NOP
+	OpFinal
 )
 
 // ReadUint16 Return a 16-bit number from the stream.
@@ -128,7 +131,7 @@ func String(op Opcode) string {
 	case OpMinus:
 		return "OpMinus"
 	case OpBang:
-		return "opBang"
+		return "OpBang"
 	case OpRoot:
 		return "OpRoot"
 	case OpLess:
@@ -136,9 +139,9 @@ func String(op Opcode) string {
 	case OpLessEqual:
 		return "OpLessEqual"
 	case OpGreater:
-		return "opGreater"
+		return "OpGreater"
 	case OpGreaterEqual:
-		return "opGreaterEqual"
+		return "OpGreaterEqual"
 	case OpEqual:
 		return "OpEqual"
 	case OpNotEqual:
@@ -152,7 +155,7 @@ func String(op Opcode) string {
 	case OpOr:
 		return "OpOr"
 	default:
-		return "Unknown"
+		return "OpUnknown"
 	}
 
 }

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -7,8 +7,7 @@ import (
 
 func TestOpcodes(t *testing.T) {
 
-	var i Opcode
-	i = 0
+	var i Opcode = 0
 
 	for i <= OpFinal {
 		x := String(i)

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -1,0 +1,21 @@
+package code
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpcodes(t *testing.T) {
+
+	var i Opcode
+	i = 0
+
+	for i <= OpFinal {
+		x := String(i)
+		if !strings.HasPrefix(x, "Op") {
+			t.Fatalf("opcode doesn't have a good prefix:%s", x)
+		}
+
+		i++
+	}
+}

--- a/eval_functions.go
+++ b/eval_functions.go
@@ -22,19 +22,28 @@ func init() {
 }
 
 // fnLen is the implementation of our `len` function.
+//
+// Interestingly this function doesn't just count the length of string
+// objects, instead we cast all objects to strings and allow their lengths
+// to be calculated.
+//
+// so `len(false)` is 5, len(3) is 1, and `len(0.123)` is 5.
 func fnLen(args []object.Object) object.Object {
 	sum := 0
 
 	for _, e := range args {
-		switch e := e.(type) {
-		case *object.String:
-			sum += utf8.RuneCountInString(e.Value)
-		}
+
+		// stringify the value, so we can call "len(3.2)", etc.
+		val := fmt.Sprintf("%v", e.Inspect())
+		sum += utf8.RuneCountInString(val)
 	}
 	return &object.Integer{Value: int64(sum)}
 }
 
 // fnLower is the implementation of our `lower` function.
+//
+// Much like the `len` function here we cast to a string before
+// we lower-case.
 func fnLower(args []object.Object) object.Object {
 
 	out := ""
@@ -42,7 +51,6 @@ func fnLower(args []object.Object) object.Object {
 	// Join all input arguments
 	for _, arg := range args {
 		val := fmt.Sprintf("%v", arg.Inspect())
-
 		out += strings.ToLower(val)
 	}
 	return &object.String{Value: out}
@@ -50,6 +58,7 @@ func fnLower(args []object.Object) object.Object {
 
 // fnMatch is the implementation of our regex `match` function.
 func fnMatch(args []object.Object) object.Object {
+
 	// We expect two arguments
 	if len(args) != 2 {
 		return &object.Boolean{Value: false}
@@ -105,6 +114,7 @@ func fnType(args []object.Object) object.Object {
 		return &object.String{Value: strings.ToLower(fmt.Sprintf("%v", e.Type()))}
 	}
 
+	// No argument is the same as a null-argument
 	return &object.String{Value: "null"}
 }
 
@@ -117,6 +127,9 @@ func fnPrint(args []object.Object) object.Object {
 }
 
 // fnUpper is the implementation of our `upper` function.
+//
+// Again we stringify our arguments here so `upper(true)` is
+// the string `TRUE`.
 func fnUpper(args []object.Object) object.Object {
 	out := ""
 
@@ -126,5 +139,4 @@ func fnUpper(args []object.Object) object.Object {
 		out += strings.ToUpper(val)
 	}
 	return &object.String{Value: out}
-
 }

--- a/eval_functions_test.go
+++ b/eval_functions_test.go
@@ -1,0 +1,213 @@
+package evalfilter
+
+import (
+	"testing"
+
+	"github.com/skx/evalfilter/object"
+)
+
+// Test string length
+func TestLen(t *testing.T) {
+
+	type TestCase struct {
+		Input  object.Object
+		Result int
+	}
+
+	tests := []TestCase{
+		{Input: &object.String{Value: "π"}, Result: 1},
+		{Input: &object.String{Value: "Steve"}, Result: 5},
+		{Input: &object.Integer{Value: 1}, Result: 1},
+		{Input: &object.Float{Value: 3.2}, Result: 3},
+		{Input: &object.Boolean{Value: true}, Result: 4},
+		{Input: &object.Boolean{Value: false}, Result: 5},
+	}
+
+	// For each test
+	for _, test := range tests {
+
+		var args []object.Object
+		args = append(args, test.Input)
+
+		x := fnLen(args)
+		if int(x.(*object.Integer).Value) != test.Result {
+			t.Errorf("Invalid length for %s", test.Input)
+		}
+	}
+}
+
+// Test lower-casing strings
+func TestLower(t *testing.T) {
+
+	type TestCase struct {
+		Input  object.Object
+		Result string
+	}
+
+	tests := []TestCase{
+		{Input: &object.String{Value: "STEVE"}, Result: "steve"},
+		{Input: &object.String{Value: "Π"}, Result: "π"},
+		{Input: &object.Integer{Value: 1}, Result: "1"},
+		{Input: &object.Float{Value: 3.2}, Result: "3.2"},
+		{Input: &object.Boolean{Value: true}, Result: "true"},
+		{Input: &object.Null{}, Result: "null"},
+	}
+
+	// For each test
+	for _, test := range tests {
+
+		var args []object.Object
+		args = append(args, test.Input)
+
+		x := fnLower(args)
+		if x.(*object.String).Value != test.Result {
+			t.Errorf("Invalid result for %t", test.Input)
+		}
+	}
+}
+
+// Test regexp-matching
+func TestMatch(t *testing.T) {
+
+	type TestCase struct {
+		String string
+		Regexp string
+		Result bool
+	}
+
+	tests := []TestCase{
+		// All tests are doubled to test the cache-handle
+		{String: "Steve", Regexp: "^Steve$", Result: true},
+		{String: "Steve", Regexp: "^Steve$", Result: true},
+
+		{String: "Steve", Regexp: "(?i)^steve$", Result: true},
+		{String: "Steve", Regexp: "(?i)^steve$", Result: true},
+
+		{String: "Steve", Regexp: "^steve$", Result: false},
+		{String: "Steve", Regexp: "^steve$", Result: false},
+
+		// invalid regexp
+		{String: "Steve", Regexp: "+", Result: false},
+		{String: "Steve", Regexp: "+", Result: false},
+	}
+
+	for _, test := range tests {
+
+		var args []object.Object
+
+		args = append(args, &object.String{Value: test.String})
+		args = append(args, &object.String{Value: test.Regexp})
+
+		res := fnMatch(args)
+
+		if res.(*object.Boolean).Value != test.Result {
+			t.Errorf("Invalid result for %s =~ /%s/", test.String, test.Regexp)
+		}
+
+	}
+
+	// Calling the function with != 2 arguments should return false
+	var args []object.Object
+	out := fnMatch(args)
+	if out.(*object.Boolean).Value != false {
+		t.Errorf("no arguments returns a weird result")
+	}
+
+}
+
+// Test trimming strings
+func TestTrim(t *testing.T) {
+
+	type TestCase struct {
+		Input  string
+		Result string
+	}
+
+	tests := []TestCase{
+		{Input: "   Steve", Result: "Steve"},
+		{Input: "Steve    ", Result: "Steve"},
+		{Input: "   Steve    ", Result: "Steve"},
+		{Input: " π   ", Result: "π"},
+		{Input: "   ", Result: ""},
+		{Input: "    π    π   ", Result: "π    π"},
+	}
+
+	// For each test
+	for _, test := range tests {
+
+		var args []object.Object
+		args = append(args, &object.String{Value: test.Input})
+
+		x := fnTrim(args)
+		if x.(*object.String).Value != test.Result {
+			t.Errorf("Invalid result for %s", test.Input)
+		}
+	}
+}
+
+// Test types
+func TestType(t *testing.T) {
+
+	type TestCase struct {
+		Input  object.Object
+		Result string
+	}
+
+	tests := []TestCase{
+		{Input: &object.String{Value: "Steve"}, Result: "string"},
+		{Input: &object.Integer{Value: 1}, Result: "integer"},
+		{Input: &object.Float{Value: 3.2}, Result: "float"},
+		{Input: &object.Boolean{Value: true}, Result: "boolean"},
+		{Input: &object.Null{}, Result: "null"},
+	}
+
+	// For each test
+	for _, test := range tests {
+
+		var args []object.Object
+		args = append(args, test.Input)
+
+		x := fnType(args)
+		if x.(*object.String).Value != test.Result {
+			t.Errorf("Invalid result for %v got %s", test.Input, x.(*object.String).Value)
+		}
+	}
+
+	// Calling the function with no-arguments should return null
+	var args []object.Object
+	out := fnType(args)
+	if out.(*object.String).Value != "null" {
+		t.Errorf("no arguments returns a weird result")
+	}
+
+}
+
+// Test upper-casing strings
+func TestUpper(t *testing.T) {
+
+	type TestCase struct {
+		Input  object.Object
+		Result string
+	}
+
+	tests := []TestCase{
+		{Input: &object.String{Value: "Steve"}, Result: "STEVE"},
+		{Input: &object.String{Value: "π"}, Result: "Π"},
+		{Input: &object.Integer{Value: 1}, Result: "1"},
+		{Input: &object.Float{Value: 3.2}, Result: "3.2"},
+		{Input: &object.Boolean{Value: true}, Result: "TRUE"},
+		{Input: &object.Null{}, Result: "NULL"},
+	}
+
+	// For each test
+	for _, test := range tests {
+
+		var args []object.Object
+		args = append(args, test.Input)
+
+		x := fnUpper(args)
+		if x.(*object.String).Value != test.Result {
+			t.Errorf("Invalid result for %s", test.Input)
+		}
+	}
+}


### PR DESCRIPTION
This will close #46, by giving us increased test-coverage.

* Updated built-in `len` to stringify the argument(s) passed.
  * Allowing `len(true)`, `len(3.4)`, etc.
  * This matches the behaviour of `lower`, `upper`, etc.
