### PR TITLE
62 move truth test to object

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -204,7 +204,7 @@ func (e *Eval) Run(obj interface{}) (bool, error) {
 	//
 	// Otherwise convert the result to a boolean, and return.
 	//
-	return e.isTruthy(out), err
+	return out.True(), err
 
 }
 
@@ -629,29 +629,5 @@ func (e *Eval) replaceInstruction(pos int, newInstruction []byte) {
 
 	for i := 0; i < len(newInstruction); i++ {
 		ins[pos+i] = newInstruction[i]
-	}
-}
-
-// isTruthy tests whether the given object is "true".
-func (e *Eval) isTruthy(obj object.Object) bool {
-
-	//
-	// Is this a boolean object?
-	//
-	// If so look for the stored value.
-	//
-	switch tmp := obj.(type) {
-	case *object.Boolean:
-		return tmp.Value
-	case *object.String:
-		return (tmp.Value != "")
-	case *object.Null:
-		return false
-	case *object.Integer:
-		return (tmp.Value != 0)
-	case *object.Float:
-		return (tmp.Value != 0.0)
-	default:
-		return true
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -25,9 +25,12 @@ const (
 // Object is the interface that all of our various object-types must implement.
 type Object interface {
 
+	// Inspect returns a string-representation of the given object.
+	Inspect() string
+
 	// Type returns the type of this object.
 	Type() Type
 
-	// Inspect returns a string-representation of the given object.
-	Inspect() string
+	// True returns whether this object is "true".
+	True() bool
 }

--- a/object/object_bool.go
+++ b/object/object_bool.go
@@ -22,5 +22,5 @@ func (b *Boolean) Inspect() string {
 
 // Is this value "true"?
 func (b *Boolean) True() bool {
-	return (b.Value == true)
+	return b.Value
 }

--- a/object/object_bool.go
+++ b/object/object_bool.go
@@ -21,6 +21,6 @@ func (b *Boolean) Inspect() string {
 }
 
 // Is this value "true"?
-func (b *Boolean) True() {
+func (b *Boolean) True() bool {
 	return (b.Value == true)
 }

--- a/object/object_bool.go
+++ b/object/object_bool.go
@@ -19,3 +19,8 @@ func (b *Boolean) Type() Type {
 func (b *Boolean) Inspect() string {
 	return fmt.Sprintf("%t", b.Value)
 }
+
+// Is this value "true"?
+func (b *Boolean) True() {
+	return (b.Value == true)
+}

--- a/object/object_bool.go
+++ b/object/object_bool.go
@@ -20,7 +20,9 @@ func (b *Boolean) Inspect() string {
 	return fmt.Sprintf("%t", b.Value)
 }
 
-// Is this value "true"?
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
 func (b *Boolean) True() bool {
 	return b.Value
 }

--- a/object/object_error.go
+++ b/object/object_error.go
@@ -17,6 +17,6 @@ func (e *Error) Inspect() string {
 }
 
 // Is this value "true"?
-func (e *Error) True() {
+func (e *Error) True() bool {
 	return false
 }

--- a/object/object_error.go
+++ b/object/object_error.go
@@ -15,3 +15,8 @@ func (e *Error) Type() Type {
 func (e *Error) Inspect() string {
 	return "ERROR: " + e.Message
 }
+
+// Is this value "true"?
+func (e *Error) True() {
+	return false
+}

--- a/object/object_error.go
+++ b/object/object_error.go
@@ -16,7 +16,9 @@ func (e *Error) Inspect() string {
 	return "ERROR: " + e.Message
 }
 
-// Is this value "true"?
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
 func (e *Error) True() bool {
 	return false
 }

--- a/object/object_float.go
+++ b/object/object_float.go
@@ -19,3 +19,8 @@ func (f *Float) Inspect() string {
 func (f *Float) Type() Type {
 	return FLOAT
 }
+
+// Is this value "true"?
+func (f *Float) True() {
+	return (f.Value != 0)
+}

--- a/object/object_float.go
+++ b/object/object_float.go
@@ -20,7 +20,9 @@ func (f *Float) Type() Type {
 	return FLOAT
 }
 
-// Is this value "true"?
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
 func (f *Float) True() bool {
 	return (f.Value != 0)
 }

--- a/object/object_float.go
+++ b/object/object_float.go
@@ -21,6 +21,6 @@ func (f *Float) Type() Type {
 }
 
 // Is this value "true"?
-func (f *Float) True() {
+func (f *Float) True() bool {
 	return (f.Value != 0)
 }

--- a/object/object_int.go
+++ b/object/object_int.go
@@ -20,7 +20,9 @@ func (i *Integer) Type() Type {
 	return INTEGER
 }
 
-// Is this value "true"?
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
 func (i *Integer) True() bool {
 	return (i.Value != 0)
 }

--- a/object/object_int.go
+++ b/object/object_int.go
@@ -19,3 +19,8 @@ func (i *Integer) Inspect() string {
 func (i *Integer) Type() Type {
 	return INTEGER
 }
+
+// Is this value "true"?
+func (i *Integer) True() {
+	return (b.Value != 0)
+}

--- a/object/object_int.go
+++ b/object/object_int.go
@@ -21,6 +21,6 @@ func (i *Integer) Type() Type {
 }
 
 // Is this value "true"?
-func (i *Integer) True() {
-	return (b.Value != 0)
+func (i *Integer) True() bool {
+	return (i.Value != 0)
 }

--- a/object/object_null.go
+++ b/object/object_null.go
@@ -13,7 +13,9 @@ func (n *Null) Inspect() string {
 	return "null"
 }
 
-// Is this value "true"?
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
 func (n *Null) True() bool {
 	return false
 }

--- a/object/object_null.go
+++ b/object/object_null.go
@@ -12,3 +12,8 @@ func (n *Null) Type() Type {
 func (n *Null) Inspect() string {
 	return "null"
 }
+
+// Is this value "true"?
+func (n *Null) True() bool {
+	return false
+}

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -16,7 +16,9 @@ func (s *String) Inspect() string {
 	return s.Value
 }
 
-// Is this value "true"?
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
 func (s *String) True() bool {
 	return (s.Value != "")
 }

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -17,6 +17,6 @@ func (s *String) Inspect() string {
 }
 
 // Is this value "true"?
-func (s *String) True() {
-	return (b.Value != "")
+func (s *String) True() bool {
+	return (s.Value != "")
 }

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -15,3 +15,8 @@ func (s *String) Type() Type {
 func (s *String) Inspect() string {
 	return s.Value
 }
+
+// Is this value "true"?
+func (s *String) True() {
+	return (b.Value != "")
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -224,7 +224,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			if err != nil {
 				return nil, err
 			}
-			if !vm.isTruthy(condition) {
+			if condition.True() {
 
 				// NOTE: We reduce the offset, becaues
 				// at the end of our loop we increment
@@ -773,42 +773,6 @@ func (vm *VM) nativeBoolToBooleanObject(input bool) *object.Boolean {
 		return True
 	}
 	return False
-}
-
-// Does the given object contain a "true-like" value?
-func (vm *VM) isTruthy(obj object.Object) bool {
-
-	//
-	// Is this a boolean object?
-	//
-	// If so look for the stored value.
-	//
-	switch tmp := obj.(type) {
-	case *object.Boolean:
-		return tmp.Value
-	case *object.String:
-		return (tmp.Value != "")
-	case *object.Null:
-		return false
-	case *object.Integer:
-		return (tmp.Value != 0)
-	case *object.Float:
-		return (tmp.Value != 0.0)
-	}
-
-	//
-	// If not we return based on our constants.
-	//
-	switch obj {
-	case Null:
-		return false
-	case True:
-		return true
-	case False:
-		return false
-	default:
-		return true
-	}
 }
 
 // lookup the name of the given field/map-member.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -224,7 +224,10 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			if err != nil {
 				return nil, err
 			}
-			if condition.True() {
+
+			// If the condition evaluated to a non-true
+			// then we change the IP.
+			if !condition.True() {
 
 				// NOTE: We reduce the offset, becaues
 				// at the end of our loop we increment


### PR DESCRIPTION
This pull request closes #62, by moving the `isTruthy` function we had duplicated in two places to inside our object-wrappers, where it belongs.