### PR TITLE
82 optimzer

### DIFF
--- a/cmd/evalfilter/run_cmd.go
+++ b/cmd/evalfilter/run_cmd.go
@@ -16,6 +16,9 @@ import (
 //
 type runCmd struct {
 
+	// Disable the bytecode optimizer
+	raw bool
+
 	// The user may specify a JSON file.
 	jsonFile string
 }
@@ -36,7 +39,7 @@ func (*runCmd) Usage() string {
 //
 func (p *runCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.jsonFile, "json", "", "The JSON file, containing the object to test the script with.")
-
+	f.BoolVar(&p.raw, "no-optimizer", false, "Disable the bytecode optimizer")
 }
 
 //
@@ -84,9 +87,17 @@ func (p *runCmd) Run(file string) {
 	eval := evalfilter.New(string(dat))
 
 	//
+	// Flags to pass to the preperation function.
+	//
+	var flags []byte
+	if p.raw {
+		flags = append(flags, evalfilter.NoOptimize)
+	}
+
+	//
 	// Prepare
 	//
-	err = eval.Prepare()
+	err = eval.Prepare(flags)
 	if err != nil {
 		fmt.Printf("Error compiling:%s\n", err.Error())
 		return

--- a/eval_test.go
+++ b/eval_test.go
@@ -790,3 +790,54 @@ func TestArrayMap(t *testing.T) {
 		t.Fatalf("Found unexpected result running script.")
 	}
 }
+
+// TestOptimizer is a simple test-case to confirm an issue is resolved
+// https://github.com/skx/evalfilter/issues/82
+func TestOptimizer(t *testing.T) {
+
+	//
+	// String
+	//
+	src := `
+value = 0;
+
+if ( 1 == 0 ) {
+   print( "Weird output\n" );
+   value = value + 1;
+}
+
+if ( 0 == 0 ) {
+   print( "Expected output\n");
+   value = value + 1;
+}
+
+if ( 1 != 1 ) {
+   print( "Weird output\n" );
+   value = value + 1;
+}
+
+print( "After" );
+
+// This should match
+if ( value == 1 ) { return true; }
+
+return false;
+`
+	obj := New(src)
+
+	p := obj.Prepare()
+	if p != nil {
+		t.Fatalf("Failed to compile")
+	}
+
+	// Run
+	ret, err := obj.Run(nil)
+	if err != nil {
+		t.Fatalf("Found unexpected error running test - %s\n", err.Error())
+	}
+
+	if !ret {
+		t.Fatalf("Found unexpected result running script.")
+	}
+
+}

--- a/optimizer.go
+++ b/optimizer.go
@@ -429,8 +429,11 @@ func (e *Eval) removeNOPs() {
 	//
 	for ip < ln {
 
+		// Get the instruction & length.
 		op := code.Opcode(e.instructions[ip])
 		opLen := code.Length(op)
+
+		// Get the opcode's argument, if any.
 		opArg := 0
 		if opLen > 1 {
 			opArg = int(binary.BigEndian.Uint16(e.instructions[ip+1 : ip+3]))
@@ -442,7 +445,14 @@ func (e *Eval) removeNOPs() {
 		switch op {
 
 		case code.OpNop:
-			// Do nothing.  Appropriate.
+			//
+			// Do nothing here, with the instruction itself.
+			//
+			// However we have to update our map with the mapping
+			// of old-instruction to new, because there might have
+			// been a jump which pointed to this NOP instruction.
+			//
+			rewrite[ip] = len(tmp)
 
 		default:
 
@@ -526,8 +536,11 @@ func (e *Eval) removeNOPs() {
 			tmp[ip+1] = b[0]
 			tmp[ip+2] = b[1]
 
-		default:
 		}
+
+		//
+		// Next instruction.
+		//
 		ip += opLen
 	}
 


### PR DESCRIPTION
This closes #82 by fixing the optimizer to work correctly if any bytecode-program contains a jump operation which jumps into an OpNop instruction.

As part of our optimizer we remove any OpNop instructions, but we'd neglected to consider the case where an instruction jumped to somethign that was _replaced_ by a OpNop instruction.  We should have rewritten the destination address, but instead reset it to zero because we didn't consider OpNop instructions valid jump-targets.
