### PR TITLE
86 tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 	 * [Built-In Functions](#built-in-functions)
      * [Variables](#variables)
   * [Standalone Use](#standalone-use)
+     * [Debugging via standalone use](debugging-via-standalone-use)
   * [Benchmarking](#benchmarking)
   * [Fuzz Testing](#fuzz-testing)
   * [Github Setup](#github-setup)
@@ -258,6 +259,54 @@ For example in the [cmd/evalfilter](cmd/evalfilter) directory you might run:
      ./evalfilter run -json on-call.json on-call.script
 
 This will test a script against a JSON object, allowing you to experiment with changing either.
+
+
+### Debugging via standalone use
+
+Using the standalone driver is very useful to debug execution of scripts,
+for example the `-debug` and `-no-optimizer` flags will change the way
+that the script is run.
+
+Consider this example:
+
+    print( "Hello, World\n" );
+    return true;
+
+You can trace how it is executed via:
+
+```
+$ evalfilter run -debug ./example.in
+
+	Stack: []
+0000	OpConstant	0000
+
+	Stack: [Hello, World\n]
+0003	OpConstant	0001
+
+	Stack: [Hello, World\n, print]
+0006	OpCall	0001
+Hello, World
+
+..
+Script gave result true
+```
+
+Here you're show the state of the stack and every execution which is executed, along with the arguments.  This is perhaps more useful when coupled with seeing the raw bytecode disassembly:
+
+```
+$ evalfilter bytecode ./example.in
+Bytecode:
+  000000	    OpConstant	0	// load constant: "Hello, World\n"
+  000003	    OpConstant	1	// load constant: "print"
+  000006	        OpCall	1	// call function with 1 arg(s)
+  000009	        OpTrue
+  000010	      OpReturn
+
+
+Constants:
+  000000 Type:STRING Value:"Hello, World\n"
+  000001 Type:STRING Value:"print"
+```
 
 
 ## Benchmarking

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 	 * [Built-In Functions](#built-in-functions)
      * [Variables](#variables)
   * [Standalone Use](#standalone-use)
-     * [Debugging via standalone use](debugging-via-standalone-use)
+     * [Debugging via standalone use](#debugging-via-standalone-use)
   * [Benchmarking](#benchmarking)
   * [Fuzz Testing](#fuzz-testing)
   * [Github Setup](#github-setup)

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Hello, World
 Script gave result true
 ```
 
-Here you're show the state of the stack and every execution which is executed, along with the arguments.  This is perhaps more useful when coupled with seeing the raw bytecode disassembly:
+Here you're show the state of the stack and every opcode which is executed, along with the arguments.  This is perhaps more useful when coupled with seeing the raw bytecode disassembly:
 
 ```
 $ evalfilter bytecode ./example.in

--- a/cmd/evalfilter/run_cmd.go
+++ b/cmd/evalfilter/run_cmd.go
@@ -9,12 +9,16 @@ import (
 
 	"github.com/google/subcommands"
 	"github.com/skx/evalfilter/v2"
+	"github.com/skx/evalfilter/v2/object"
 )
 
 //
 // The options set by our command-line flags.  A json file
 //
 type runCmd struct {
+
+	// Show execution as it happens
+	debug bool
 
 	// Disable the bytecode optimizer
 	raw bool
@@ -40,6 +44,7 @@ func (*runCmd) Usage() string {
 func (p *runCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.jsonFile, "json", "", "The JSON file, containing the object to test the script with.")
 	f.BoolVar(&p.raw, "no-optimizer", false, "Disable the bytecode optimizer")
+	f.BoolVar(&p.debug, "debug", false, "Show instructions and the stack at ever step")
 }
 
 //
@@ -92,6 +97,15 @@ func (p *runCmd) Run(file string) {
 	var flags []byte
 	if p.raw {
 		flags = append(flags, evalfilter.NoOptimize)
+	}
+
+	//
+	// If we're to debug then set the appropriate variable
+	//
+	// NOTE: This must be done before `prepare` is invoked.
+	//
+	if p.debug {
+		eval.SetVariable("DEBUG", &object.Boolean{Value: true})
 	}
 
 	//

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -4,6 +4,7 @@ package stack
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/skx/evalfilter/v2/object"
 )
@@ -31,6 +32,21 @@ func New() *Stack {
 // Empty returns true if the stack is empty.
 func (s *Stack) Empty() bool {
 	return (len(s.entries) == 0)
+}
+
+// Export returns copy of the stack-contents, in string-form.
+//
+// This is used when tracing execution of programs.
+func (s *Stack) Export() []string {
+	var ret []string
+
+	for _, ent := range s.entries {
+		s := ent.Inspect()
+		s = strings.ReplaceAll(s, "\n", "\\n")
+
+		ret = append(ret, s)
+	}
+	return ret
 }
 
 // Size retrieves the number of entries stored upon the stack.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -143,9 +143,8 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 		}
 
 		if vm.debug {
-			fmt.Printf("\n\tStack: [")
-			fmt.Printf(strings.Join(vm.stack.Export(), ", "))
-			fmt.Printf("]\n")
+			fmt.Printf("\n\tStack: [%s]\n",
+				strings.Join(vm.stack.Export(), ", "))
 
 			if opLen > 1 {
 				fmt.Printf("%04d\t%s\t%04d\n", ip, code.String(op), opArg)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -34,10 +34,10 @@ var Null = &object.Null{}
 // VM is the structure which holds our state.
 type VM struct {
 
-	// constants holds constants in the program source, these
-	// are string-literals, numeric-literals, boolean values
-	// as well as variable names, the names of functions, and
-	// references to object/map values.
+	// constants is an array holding constants which were found in
+	// the script-source.  These constants include string-literals,
+	// numeric-literals, boolean values as well as variable names, the
+	// names of functions, and references to object/map values.
 	//
 	// constants are treated as atoms, so they are unique.
 	constants []object.Object
@@ -62,16 +62,23 @@ type VM struct {
 	// Reflection is slow so the map here is used as a cache, avoiding
 	// the need to reparse the same object multiple times.
 	fields map[string]object.Object
+
+	// debug can be enabled to dump our execution-log as we run.
+	debug bool
 }
 
 // New constructs a new virtual machine.
 func New(constants []object.Object, bytecode code.Instructions, env *environment.Environment) *VM {
+
+	// If we have a `DEBUG` environment then we enable debugging
+	_, present := env.Get("DEBUG")
 
 	return &VM{
 		constants:   constants,
 		environment: env,
 		bytecode:    bytecode,
 		stack:       stack.New(),
+		debug:       present,
 	}
 }
 
@@ -133,6 +140,19 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			// and they might be different sizes.
 			//
 			opArg = int(binary.BigEndian.Uint16(vm.bytecode[ip+1 : ip+3]))
+		}
+
+		if vm.debug {
+			fmt.Printf("\n\tStack: [")
+			fmt.Printf(strings.Join(vm.stack.Export(), ", "))
+			fmt.Printf("]\n")
+
+			if opLen > 1 {
+				fmt.Printf("%04d\t%s\t%04d\n", ip, code.String(op), opArg)
+			} else {
+				fmt.Printf("%04d\t%s\n", ip, code.String(op))
+			}
+
 		}
 
 		switch op {


### PR DESCRIPTION
This pull-request updates #86, by adding the ability to trace every opcode which is executed, and view the stack-content at the same time.

 