### PR TITLE
Add support for time.Time in objects/maps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _examples/passwd/passwd
 _examples/variable/variable
 _examples/state/state
+_examples/time/time
 cmd/evalfilter/evalfilter
 go.sum
 workdir/

--- a/_examples/time/main.go
+++ b/_examples/time/main.go
@@ -1,0 +1,87 @@
+// This example demonstrates working with `time.Time`.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/skx/evalfilter/v2"
+)
+
+//
+// Entry-point
+//
+func main() {
+
+	//
+	// We'll use an instance of this object to run our script against.
+	//
+	// Here the important thing is the `At` field.
+	//
+	type Input struct {
+		Message string
+		At      time.Time
+	}
+
+	//
+	// Create an instance of this object.
+	//
+	in := &Input{Message: "This is a test",
+		At: time.Now()}
+
+	//
+	// This is the script we'll run.
+	//
+	input := `
+
+if ( hour(At) < 07 || hour(At) >= 14) {
+   print( "This is out of hours ..\n" );
+}
+
+print( "The message is '", Message, "'\n" );
+print( "The time was '", At, "'\n" );
+print( "In a more humane format that is ",
+       hour( At ), ":", minute( At), ":", seconds(At) ,
+       "\n" );
+print( "The message was sent upon ", weekday(At), "\n" );
+print( "The date was " , day(At), "/", month(At), "/", year(At), "\n");
+
+// No real decision here.
+return true;
+`
+
+	//
+	// Create an evaluator, with the given script.
+	//
+	eval := evalfilter.New(input)
+
+	//
+	// Prepare the script
+	//
+	err := eval.Prepare()
+	if err != nil {
+		fmt.Printf("Failed to compile script: %s\n", err.Error())
+		return
+	}
+
+	//
+	// Run our script, using the instance of the structure.
+	//
+	ret, err := eval.Run(in)
+	if err != nil {
+		fmt.Printf("Failed to run script:%s\n", err.Error())
+		return
+	}
+
+	//
+	// Show the output.
+	//
+	if ret {
+		fmt.Printf("Script gave result %v\n\n", ret)
+	}
+
+	//
+	// All done
+	//
+}

--- a/environment/builtins.go
+++ b/environment/builtins.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/skx/evalfilter/v2/object"
@@ -232,4 +233,82 @@ func fnUpper(args []object.Object) object.Object {
 
 	// Return
 	return &object.String{Value: arg}
+}
+
+// getTimeField handles returning a time-related field from an object
+// which is assumed to contain a time in the Unix Epoch format.
+func getTimeField(args []object.Object, val string) object.Object {
+
+	// We expect one argument
+	if len(args) != 1 {
+		return &object.Null{}
+	}
+
+	// It must be an integer
+	if args[0].Type() != object.INTEGER {
+		return &object.Null{}
+	}
+
+	// Convert that to a time
+	time := time.Unix(args[0].(*object.Integer).Value, 0)
+
+	// Now get the fields
+	hr, min, sec := time.Clock()
+	year, month, day := time.Date()
+
+	// And return the one we should
+	switch val {
+	case "hour":
+		return &object.Integer{Value: int64(hr)}
+	case "minute":
+		return &object.Integer{Value: int64(min)}
+	case "seconds":
+		return &object.Integer{Value: int64(sec)}
+	case "day":
+		return &object.Integer{Value: int64(day)}
+	case "month":
+		return &object.Integer{Value: int64(month)}
+	case "year":
+		return &object.Integer{Value: int64(year)}
+	case "weekday":
+		return &object.String{Value: fmt.Sprintf("%s", time.Weekday())}
+	}
+
+	// Unknown field: can't happen?
+	return &object.Null{}
+}
+
+// fnHour returns the hour of the given time-object.
+func fnHour(args []object.Object) object.Object {
+	return getTimeField(args, "hour")
+}
+
+// fnMinute returns the minute of the given time-object.
+func fnMinute(args []object.Object) object.Object {
+	return getTimeField(args, "minute")
+}
+
+// fnSeconds returns the seconds of the given time-object.
+func fnSeconds(args []object.Object) object.Object {
+	return getTimeField(args, "seconds")
+}
+
+// fnDay returns the day of the given time-object.
+func fnDay(args []object.Object) object.Object {
+	return getTimeField(args, "day")
+}
+
+// fnMonth returns the month of the given time-object.
+func fnMonth(args []object.Object) object.Object {
+	return getTimeField(args, "month")
+}
+
+// fnYear returns the year of the given time-object.
+func fnYear(args []object.Object) object.Object {
+	return getTimeField(args, "year")
+}
+
+// fnWeekday returns the name of the day in the given time-object.
+func fnWeekday(args []object.Object) object.Object {
+	return getTimeField(args, "weekday")
 }

--- a/environment/builtins.go
+++ b/environment/builtins.go
@@ -271,7 +271,7 @@ func getTimeField(args []object.Object, val string) object.Object {
 	case "year":
 		return &object.Integer{Value: int64(year)}
 	case "weekday":
-		return &object.String{Value: fmt.Sprintf("%s", time.Weekday())}
+		return &object.String{Value: time.Weekday().String()}
 	}
 
 	// Unknown field: can't happen?

--- a/environment/builtins_test.go
+++ b/environment/builtins_test.go
@@ -457,7 +457,7 @@ func TestTime(t *testing.T) {
 		t.Errorf("Failed to get the correct date")
 	}
 
-	if fnHour(args).(*object.Integer).Value != 16 {
+	if fnHour(args).(*object.Integer).Value != 14 {
 		t.Errorf("Failed to get the correct time")
 	}
 	if fnMinute(args).(*object.Integer).Value != 15 {

--- a/environment/builtins_test.go
+++ b/environment/builtins_test.go
@@ -397,3 +397,91 @@ func TestPrint(t *testing.T) {
 	args = append(args, &object.String{Value: ""})
 	fnPrint(args)
 }
+
+// TestTime performs *minimal* invocation of time-fields
+func TestTime(t *testing.T) {
+
+	//
+	// Call all the functions with no arguments
+	//
+	var args []object.Object
+	var out object.Object
+
+	out = fnHour(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+	out = fnMinute(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+	out = fnSeconds(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+	out = fnDay(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+	out = fnMonth(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+	out = fnYear(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+	out = fnWeekday(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+
+	//
+	// Now create a known-time
+	//
+	args = append(args, &object.Integer{Value: 195315316})
+
+	//
+	// And check the values.
+	//
+	if fnDay(args).(*object.Integer).Value != 10 {
+		t.Errorf("Failed to get the correct date")
+	}
+	if fnMonth(args).(*object.Integer).Value != 3 {
+		t.Errorf("Failed to get the correct date")
+	}
+	if fnYear(args).(*object.Integer).Value != 1976 {
+		t.Errorf("Failed to get the correct date")
+	}
+	if fnWeekday(args).(*object.String).Value != "Wednesday" {
+		t.Errorf("Failed to get the correct date")
+	}
+
+	if fnHour(args).(*object.Integer).Value != 16 {
+		t.Errorf("Failed to get the correct time")
+	}
+	if fnMinute(args).(*object.Integer).Value != 15 {
+		t.Errorf("Failed to get the correct time")
+	}
+	if fnSeconds(args).(*object.Integer).Value != 16 {
+		t.Errorf("Failed to get the correct time")
+	}
+
+	//
+	// Test bogus field-name to the internal-helper.
+	//
+	if getTimeField(args, "bogus").Type() != object.NULL {
+		t.Errorf("unexpected value passing bogus argument")
+	}
+
+	//
+	// Finally check with a bogus-type to one of the methods
+	//
+	var bogus []object.Object
+	bogus = append(bogus, &object.String{Value: "not int"})
+
+	if fnSeconds(bogus).Type() != object.NULL {
+		t.Errorf("unexpected value passing bogus argument")
+	}
+
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -41,6 +41,28 @@ func New() *Environment {
 	env.SetFunction("int", fnInt)
 	env.SetFunction("float", fnFloat)
 
+	//
+	// These all refer to time.Time fields.
+	//
+	// (Though they will work on any object which
+	// is an integer.  Because when we examine time.Time
+	// fields via reflection we convert them to Unix epoch
+	// seconds.)
+	//
+
+	// 10:11:12, etc.
+	env.SetFunction("hour", fnHour)
+	env.SetFunction("minute", fnMinute)
+	env.SetFunction("seconds", fnSeconds)
+
+	// 10/03/1976, etc.
+	env.SetFunction("day", fnDay)
+	env.SetFunction("month", fnMonth)
+	env.SetFunction("year", fnYear)
+
+	// "Saturday", "Sunday", etc.
+	env.SetFunction("weekday", fnWeekday)
+
 	// All done.
 	return env
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -134,7 +134,7 @@ func TestEq(t *testing.T) {
 	tests := []Test{
 		{Input: `if ( Count == 12.4 ) { return true; } return false;`, Result: true},
 		{Input: `if ( len(trim(" steve " ) ) == 5 ) { return true; } return false;`, Result: true},
-		{Input: `if ( len(trim() ) == 0 ) { return true; } return false;`, Result: true},
+		{Input: `if ( len(trim("   ") ) == 0 ) { return true; } return false;`, Result: true},
 		{Input: `if ( Count == 3 ) { return true; } return false;`, Result: false},
 		{Input: `if ( Count != 1 ) { return true; }`, Result: true},
 		{Input: `if ( Count != 12.4 ) { return false; } return true;`, Result: true},
@@ -157,7 +157,7 @@ func TestEq(t *testing.T) {
 		}
 
 		if ret != tst.Result {
-			t.Fatalf("Found unexpected result running script")
+			t.Fatalf("Found unexpected result running script: %s", tst.Input)
 		}
 	}
 }


### PR DESCRIPTION
This pull-request, when complete, will close #88, by giving us complete support for the use of golang's `time.Time` values in objects/maps we're given to work upon.

To simplify our coding we'll parse time objects and internally store them as seconds-past-the-epoch as `object.Integers`.  This means we'll need built-in functions to access the fields from those times.
