### PR TITLE
Improve regexp support

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -454,6 +454,11 @@ func (l *Lexer) readRegexp() (string, error) {
 			}
 			break
 		}
+		if l.ch == '\\' {
+			// Skip the escape-marker, and read the
+			// escaped character literally.
+			l.readChar()
+		}
 		out = out + string(l.ch)
 	}
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -422,7 +422,9 @@ func (l *Lexer) readRegexp() (string, error) {
 			//   i -> Ignore-case
 			//   m -> Multiline
 			//
-			for l.ch == rune('i') || l.ch == rune('m') {
+			// We need to consume all letters, so we can
+			// alert on illegal ones.
+			for unicode.IsLetter(l.ch) {
 
 				// save the char - unless it is a repeat
 				if !strings.Contains(flags, string(l.ch)) {
@@ -438,6 +440,14 @@ func (l *Lexer) readRegexp() (string, error) {
 				l.readChar()
 			}
 
+			for _, c := range flags {
+				switch c {
+				case 'i', 'm':
+					// nop
+				default:
+					return "", fmt.Errorf("illegal regexp flag '%c' in string '%s'", c, flags)
+				}
+			}
 			// convert the regexp to go-lang
 			if len(flags) > 0 {
 				out = "(?" + flags + ")" + out

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -341,6 +341,7 @@ func TestLine(t *testing.T) {
 func TestRegexp(t *testing.T) {
 	input := `if ( f ~= /steve/i )
 if ( f ~= /steve/m )
+if ( f ~= /steve\//m )
 if ( f ~= /steve/mi )
 if ( f ~= /steve/miiiiiiiiiiiiiiiiimmmmmmmmmmmmmiiiii )
 if ( f ~= /steve/fx )`
@@ -363,6 +364,14 @@ if ( f ~= /steve/fx )`
 		{token.IDENT, "f"},
 		{token.CONTAINS, "~="},
 		{token.REGEXP, "(?m)steve"},
+		{token.RPAREN, ")"},
+
+		// if ( f ~= /steve\//m )
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.REGEXP, "(?m)steve/"},
 		{token.RPAREN, ")"},
 
 		// if ( f ~= /steve/mi )

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -342,43 +342,60 @@ func TestRegexp(t *testing.T) {
 	input := `if ( f ~= /steve/i )
 if ( f ~= /steve/m )
 if ( f ~= /steve/mi )
-if ( f ~= /steve/miiiiiiiiiiiiiiiiimmmmmmmmmmmmmiiiii )`
+if ( f ~= /steve/miiiiiiiiiiiiiiiiimmmmmmmmmmmmmiiiii )
+if ( f ~= /steve/fx )`
 
 	tests := []struct {
 		expectedType    token.Type
 		expectedLiteral string
 	}{
+		// if ( f ~= /steve/i )
 		{token.IF, "if"},
 		{token.LPAREN, "("},
 		{token.IDENT, "f"},
 		{token.CONTAINS, "~="},
 		{token.REGEXP, "(?i)steve"},
 		{token.RPAREN, ")"},
+
+		// if ( f ~= /steve/m )
 		{token.IF, "if"},
 		{token.LPAREN, "("},
 		{token.IDENT, "f"},
 		{token.CONTAINS, "~="},
 		{token.REGEXP, "(?m)steve"},
 		{token.RPAREN, ")"},
+
+		// if ( f ~= /steve/mi )
 		{token.IF, "if"},
 		{token.LPAREN, "("},
 		{token.IDENT, "f"},
 		{token.CONTAINS, "~="},
 		{token.REGEXP, "(?mi)steve"},
 		{token.RPAREN, ")"},
+
+		//if ( f ~= /steve/miiiiiiiiiiiiiiiiimmmmmmmmmmmmmiiiii )`
 		{token.IF, "if"},
 		{token.LPAREN, "("},
 		{token.IDENT, "f"},
 		{token.CONTAINS, "~="},
 		{token.REGEXP, "(?mi)steve"},
 		{token.RPAREN, ")"},
+
+		//if ( f ~= /steve/fx )`
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.IDENT, "f"},
+		{token.CONTAINS, "~="},
+		{token.ILLEGAL, "illegal regexp flag 'f' in string 'fx'"},
+		{token.RPAREN, ")"},
+
 		{token.EOF, ""},
 	}
 	l := New(input)
 	for i, tt := range tests {
 		tok := l.NextToken()
 		if tok.Type != tt.expectedType {
-			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+			t.Fatalf("test[%s] - tokentype wrong, expected=%q, got=%q", tt, tt.expectedType, tok.Type)
 		}
 		if tok.Literal != tt.expectedLiteral {
 			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)


### PR DESCRIPTION
This pull-request will close #97, once complete.

Currently only allow `m` + `i` to be regexp flags, anything else will raise an error at lex-time.

TODO:  Handle escaping-characters, as we do for strings.