### PR TITLE
103 range operation

### DIFF
--- a/ast/ast_foreach.go
+++ b/ast/ast_foreach.go
@@ -1,0 +1,38 @@
+package ast
+
+import (
+	"bytes"
+
+	"github.com/skx/evalfilter/v2/token"
+)
+
+// ForeachStatement holds a foreach-statement.
+type ForeachStatement struct {
+	// Token is the actual token
+	Token token.Token
+
+	// Ident is the variable we'll set with each item, for the blocks' scope
+	Ident string
+
+	// Value is the thing we'll range over.
+	Value Expression
+
+	// Body is the block we'll execute.
+	Body *BlockStatement
+}
+
+func (fes *ForeachStatement) expressionNode() {}
+
+// TokenLiteral returns the literal token.
+func (fes *ForeachStatement) TokenLiteral() string { return fes.Token.Literal }
+
+// String returns this object as a string.
+func (fes *ForeachStatement) String() string {
+	var out bytes.Buffer
+	out.WriteString("foreach ")
+	out.WriteString(fes.Ident)
+	out.WriteString(" ")
+	out.WriteString(fes.Value.String())
+	out.WriteString(fes.Body.String())
+	return out.String()
+}

--- a/code/code.go
+++ b/code/code.go
@@ -139,6 +139,30 @@ const (
 	// contained in the second-argument (which must be an array),
 	// push TRUE, else push FALSE
 	OpArrayIn
+
+	// OpNext is used for walking over items in an array.
+	//
+	// It is a horrible opcode because the interpreter shares
+	// knowledge on the back-end with the fake-code generated
+	// on the front-end.
+	//
+	// Assuming an array is on the stack (!):
+	//
+	//  1. We pop the array FROM the stack.
+	//
+	//  2. We push the array back, after bumping the count-field.
+	//
+	//  3. We then push the next item.
+	//
+	//  4. We then push TRUE - which lets our OpJumpIfFalse work.
+	//
+	// UNLESS we're at the end, in which case we do:
+	//
+	//  1.  We pop the value FRM the stack
+	//
+	//  2.  We push FALSE - breaking out of out body.
+	//
+	OpNext
 )
 
 // OpCodeNames allows mapping opcodes to their names.
@@ -176,6 +200,7 @@ var OpCodeNames = [...]string{
 	OpSquareRoot:   "OpSquareRoot",
 	OpSub:          "OpSub",
 	OpTrue:         "OpTrue",
+	OpNext:         "OpNext",
 }
 
 // Length returns the length of the given opcode, including any optional

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -908,6 +908,11 @@ func TestForeach(t *testing.T) {
 return len(item) == 5 ; };
 return false;`,
 			Result: true},
+		{Input: `sum = 0 ; foreach item in [1, 2, 3, 4] {
+sum = sum + item; }
+return( sum == 10 );
+`,
+			Result: true},
 	}
 
 	for _, tst := range tests {

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -892,6 +892,43 @@ return( "Steve" in [ "Steve", "Blah", "Kemp" ] );
 	}
 }
 
+// TestForeach tests our foreach loop, at least a little
+func TestForeach(t *testing.T) {
+
+	type Test struct {
+		Input  string
+		Result bool
+	}
+
+	tests := []Test{
+
+		{Input: `foreach item in ["Steve" ] { return true; }`,
+			Result: true},
+		{Input: `foreach item in ["Steve", "Kemp"] {
+return len(item) == 5 ; };
+return false;`,
+			Result: true},
+	}
+
+	for _, tst := range tests {
+
+		obj := New(tst.Input)
+
+		p := obj.Prepare()
+		if p != nil {
+			t.Fatalf("Failed to compile: %s - %s", tst.Input, p.Error())
+		}
+
+		ret, err := obj.Run(nil)
+		if err != nil {
+			t.Fatalf("Found unexpected error running script: %s : %s", tst.Input, err.Error())
+		}
+		if ret != tst.Result {
+			t.Fatalf("Found unexpected result running script: %s", tst.Input)
+		}
+	}
+}
+
 // TestTernary checks our simple tenary expression(s)
 func TestTernary(t *testing.T) {
 

--- a/object/object_array.go
+++ b/object/object_array.go
@@ -9,6 +9,9 @@ import (
 type Array struct {
 	// Elements holds the individual members of the array we're wrapping.
 	Elements []Object
+
+	// Offset is used for array walking.
+	Offset int
 }
 
 // Type returns the type of this object.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -114,6 +114,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.EOF, p.parseEOF)
 	p.registerPrefix(token.FALSE, p.parseBooleanLiteral)
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
+	p.registerPrefix(token.FOREACH, p.parseForEach)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.ILLEGAL, p.parseIllegal)
@@ -428,6 +429,32 @@ func (p *Parser) parseIfExpression() ast.Expression {
 			return nil
 		}
 	}
+	return expression
+}
+
+// parseForEach parses 'foreach x X { .. block .. }`
+func (p *Parser) parseForEach() ast.Expression {
+	expression := &ast.ForeachStatement{Token: p.curToken}
+
+	// get the id
+	p.nextToken()
+	expression.Ident = p.curToken.Literal
+
+	// skip to the next token - which should be IN
+	p.nextToken()
+	if p.curTokenIs(token.IN) {
+		p.nextToken()
+	} else {
+		return nil
+	}
+
+	// get the ranged item
+	expression.Value = p.parseExpression(LOWEST)
+
+	// get the body
+	p.nextToken()
+	expression.Body = p.parseBlockStatement()
+
 	return expression
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -32,6 +32,7 @@ const (
 	EQ        = "=="
 	FALSE     = "FALSE"
 	FLOAT     = "FLOAT"
+	FOREACH   = "FOREACH"
 	GT        = ">"
 	GTEQUALS  = ">="
 	IDENT     = "IDENT"
@@ -68,13 +69,14 @@ const (
 
 // reversed keywords
 var keywords = map[string]Type{
-	"else":   ELSE,
-	"false":  FALSE,
-	"if":     IF,
-	"in":     IN,
-	"return": RETURN,
-	"true":   TRUE,
-	"while":  WHILE,
+	"else":    ELSE,
+	"false":   FALSE,
+	"foreach": FOREACH,
+	"if":      IF,
+	"in":      IN,
+	"return":  RETURN,
+	"true":    TRUE,
+	"while":   WHILE,
 }
 
 // LookupIdentifier used to determinate whether identifier is keyword nor not

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -416,7 +416,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 
 			obj, ok := out.(*object.Array)
 			if !ok {
-				return nil, fmt.Errorf("object not an array:%t", obj)
+				return nil, fmt.Errorf("object not an array:%v", obj)
 			}
 
 			if obj.Offset < len(obj.Elements) {


### PR DESCRIPTION
Implement `foreach` support:

```
// Show the array
foreach item in [ "Steve", "Kemp" ] {
   print( "This is the element: ", item, "\n");
}

return false;
```

We don't get access to the index, but we do get the value.  We could fix that later if we need it.  This will fix #103 once merged - but note we have also changed the handling of `OpCall`, as per #86, and that needs to be fixed next.