### PR TITLE
Add a void-object, and use it.

### DIFF
--- a/environment/builtins.go
+++ b/environment/builtins.go
@@ -236,7 +236,7 @@ func fnPrint(args []object.Object) object.Object {
 	for _, e := range args {
 		fmt.Printf("%s", e.Inspect())
 	}
-	return &object.Integer{Value: 0}
+	return &object.Void{}
 }
 
 // fnPrintf is the implementation of our `printf` function.
@@ -250,12 +250,9 @@ func fnPrintf(args []object.Object) object.Object {
 	if out.Type() == object.STRING {
 		fmt.Print(out.(*object.String).Value)
 
-		// Success.
-		return &object.Boolean{Value: true}
 	}
 
-	// Failure.
-	return &object.Boolean{Value: false}
+	return &object.Void{}
 }
 
 // fnSprintf is the implementation of our `sprintf` function.

--- a/environment/builtins_test.go
+++ b/environment/builtins_test.go
@@ -600,8 +600,7 @@ func TestSprintf(t *testing.T) {
 func TestPrintf(t *testing.T) {
 
 	type TestCase struct {
-		Input  []object.Object
-		Result bool
+		Input []object.Object
 	}
 
 	tests := []TestCase{
@@ -609,39 +608,35 @@ func TestPrintf(t *testing.T) {
 			&object.String{Value: "%s %s"},
 			&object.String{Value: "steve"},
 			&object.String{Value: "kemp"}},
-			Result: true},
+		},
 
 		{Input: []object.Object{
 			&object.String{Value: "%d"},
 			&object.Integer{Value: 12}},
-			Result: true},
+		},
 
 		{Input: []object.Object{
 			&object.String{Value: "%f %d"},
 			&object.Float{Value: 3.222219},
 			&object.Integer{Value: -3}},
-			Result: true},
+		},
 
 		{Input: []object.Object{
 			&object.String{Value: "%t %t %t"},
 			&object.Boolean{Value: true},
 			&object.Boolean{Value: false},
 			&object.Boolean{Value: true}},
-			Result: true},
+		},
 
-		{Input: []object.Object{&object.String{Value: "%%"}},
-			Result: true},
+		{Input: []object.Object{&object.String{Value: "%%"}}},
 
-		{Input: []object.Object{&object.String{Value: "no arguments"}},
-			Result: true},
+		{Input: []object.Object{&object.String{Value: "no arguments"}}},
 
 		// no arg
-		{Input: []object.Object{},
-			Result: false},
+		{Input: []object.Object{}},
 
 		// bad type
-		{Input: []object.Object{&object.Boolean{Value: false}},
-			Result: false},
+		{Input: []object.Object{&object.Boolean{Value: false}}},
 	}
 
 	// For each test
@@ -651,8 +646,9 @@ func TestPrintf(t *testing.T) {
 		args = append(args, test.Input...)
 
 		x := fnPrintf(args)
-		if x.(*object.Boolean).Value != test.Result {
-			t.Errorf("Invalid result for test %d, got %s", i, x)
+		if x.Type() != object.VOID {
+			t.Errorf("Invalid return type for test %d, got %s", i, x)
 		}
+
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -26,6 +26,7 @@ const (
 	INTEGER = "INTEGER"
 	NULL    = "NULL"
 	STRING  = "STRING"
+	VOID    = "VOID"
 )
 
 // Object is the interface that all of our various object-types must implement.

--- a/object/object_void.go
+++ b/object/object_void.go
@@ -1,0 +1,29 @@
+package object
+
+// Void wraps nothing and implements our Object interface.
+type Void struct{}
+
+// Type returns the type of this object.
+func (v *Void) Type() Type {
+	return VOID
+}
+
+// Inspect returns a string-representation of the given object.
+func (v *Void) Inspect() string {
+	return "void"
+}
+
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
+func (v *Void) True() bool {
+	return false
+}
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (v *Void) ToInterface() interface{} {
+	return nil
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -402,7 +402,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 
 			// store the result back on the stack - unless
 			// it's a weird one.
-			if name != "print" && name != "printf" {
+			if ret.Type() != object.VOID {
 				vm.stack.Push(ret)
 			}
 


### PR DESCRIPTION
The void-object allows a built-in function to NOT return a result,
which means that we won't needlessly pad the stack with an extra
value which isn't used.

This will be very helpful when people extend the engine with
their own primitives, and also for the built in `printf` and `print`
functions.

This closes #106.