### PR TITLE
113 range strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,18 @@ Again as you'd expect the facilities are pretty normal/expected:
 * There are series of built-in primitives which can be used by your scripts, and you can export your own host-specified functions easily.
   * For example the `print` function to generate output from your script is just a simple function implemented in Golang and exported to the environment.
 
-Our script allows looping over arrays, via the `foreach` function:
+Our script allows looping over arrays and string, via the `foreach` function:
 
     foreach item in [ "My", "name", "is", "Steve" ] {
         print( item, "\t" );
     }
     return false;
+
+    len = 0;
+    foreach char in "狐犬" {
+        len++;
+    }
+    return( len == 2 );
 
 And new arrays can be created with integers via the `..` helper:
 

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -918,6 +918,19 @@ sum = sum + item; }
 return( sum == 10 );
 `,
 			Result: true},
+		{Input: `
+str = "狐犬"; len = 0;
+foreach char in str { len++ }
+return len == 2 ;
+`,
+			Result: true},
+		{Input: `
+str = "狐犬"; len = 0;
+foreach char in str { len++ }
+foreach char in str { len++ }
+return len == 4 ;
+`,
+			Result: true},
 		{Input: `return( len( 1..10 ) == 10);`,
 			Result: true},
 		{Input: `return( len( 9..10 ) == 2);`,

--- a/object/object.go
+++ b/object/object.go
@@ -72,3 +72,14 @@ type Decrement interface {
 	// Decrease lowers the object's value by one.
 	Decrease()
 }
+
+// Iterable is the interface that any object must implement if
+// it is to be iterated over with the `foreach` built-in.
+type Iterable interface {
+
+	// Reset the state of any previous iteration.
+	Reset()
+
+	// Get the next "thing" from the object.
+	Next() (Object, int, bool)
+}

--- a/object/object_array.go
+++ b/object/object_array.go
@@ -10,8 +10,8 @@ type Array struct {
 	// Elements holds the individual members of the array we're wrapping.
 	Elements []Object
 
-	// Offset is used for array walking.
-	Offset int
+	// offset holds our iteration-offset.
+	offset int
 }
 
 // Type returns the type of this object.
@@ -52,4 +52,23 @@ func (ao *Array) ToInterface() interface{} {
 	}
 
 	return res
+}
+
+// Reset implements the Iterable interface, and allows the contents
+// of the array to be reset to allow re-iteration.
+func (ao *Array) Reset() {
+	ao.offset = 0
+}
+
+// Next implements the Iterable interface, and allows the contents
+// of our array to be iterated over.
+func (ao *Array) Next() (Object, int, bool) {
+	if ao.offset < len(ao.Elements) {
+		ao.offset++
+
+		element := ao.Elements[ao.offset-1]
+		return element, ao.offset - 1, true
+	}
+
+	return nil, 0, false
 }

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -1,9 +1,14 @@
 package object
 
+import "unicode/utf8"
+
 // String wraps string and implements the Object interface.
 type String struct {
 	// Value holds the string value this object wraps.
 	Value string
+
+	// Offset holds our iteration-offset
+	offset int
 }
 
 // Type returns the type of this object.
@@ -29,4 +34,29 @@ func (s *String) True() bool {
 // It might also be helpful for embedded users.
 func (s *String) ToInterface() interface{} {
 	return s.Value
+}
+
+// Reset implements the Iterable interface, and allows the contents
+// of the string to be reset to allow re-iteration.
+func (s *String) Reset() {
+	s.offset = 0
+}
+
+// Next implements the Iterable interface, and allows the contents
+// of our string to be iterated over.
+func (s *String) Next() (Object, int, bool) {
+
+	if s.offset < utf8.RuneCountInString(s.Value) {
+		s.offset++
+
+		// Get the characters as an array of runes
+		chars := []rune(s.Value)
+
+		// Now index
+		val := String{Value: string(chars[s.offset-1])}
+
+		return &val, s.offset - 1, true
+	}
+
+	return nil, 0, false
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -416,7 +416,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			// Reset it.
 			helper, ok := out.(object.Iterable)
 			if !ok {
-				return nil, fmt.Errorf("%s object doesn't implement the Iterable interface.", out.Type())
+				return nil, fmt.Errorf("%s object doesn't implement the Iterable interface", out.Type())
 			}
 			helper.Reset()
 			vm.stack.Push(out)
@@ -431,7 +431,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 
 			helper, ok := out.(object.Iterable)
 			if !ok {
-				return nil, fmt.Errorf("%s object doesn't implement the Iterable interface.", out.Type())
+				return nil, fmt.Errorf("%s object doesn't implement the Iterable interface", out.Type())
 			}
 
 			obj, _, ok := helper.Next()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -414,12 +414,11 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			}
 
 			// Reset it.
-			obj, ok := out.(*object.Array)
+			helper, ok := out.(object.Iterable)
 			if !ok {
-				return nil, fmt.Errorf("object not an array:%v", obj)
+				return nil, fmt.Errorf("%s object doesn't implement the Iterable interface.", out.Type())
 			}
-
-			obj.Offset = 0
+			helper.Reset()
 			vm.stack.Push(out)
 
 		case code.OpIterationNext:
@@ -430,15 +429,15 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 				return nil, err
 			}
 
-			obj, ok := out.(*object.Array)
+			helper, ok := out.(object.Iterable)
 			if !ok {
-				return nil, fmt.Errorf("object not an array:%v", obj)
+				return nil, fmt.Errorf("%s object doesn't implement the Iterable interface.", out.Type())
 			}
 
-			if obj.Offset < len(obj.Elements) {
-				obj.Offset++
+			obj, _, ok := helper.Next()
+			if ok {
+				vm.stack.Push(out)
 				vm.stack.Push(obj)
-				vm.stack.Push(obj.Elements[obj.Offset-1])
 				vm.stack.Push(True)
 			} else {
 				vm.stack.Push(False)
@@ -496,6 +495,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			helper.Increase()
 			vm.environment.Set(name, val)
 
+			vm.stack.Pop()
 		case code.OpDec:
 			// Get the name of the variable whos' contents
 			// we should decrement.
@@ -513,7 +513,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			// Mutate & store
 			helper.Decrease()
 			vm.environment.Set(name, val)
-
+			vm.stack.Pop()
 		default:
 			return nil, fmt.Errorf("unhandled opcode: %v %s", op, code.String(op))
 		}


### PR DESCRIPTION
The `foreach` primitive now allows iterating over the contents of strings, not just arrays.

Test case added, and a frustrating bug with the OpInc / OpDec primitives fixed - they each left an extra item on the stack.

This closes #113.