### PR TITLE
Fix string-indexing operations to work with UTF

### DIFF
--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1010,3 +1010,35 @@ return( a == 1 ? true ? true : false : false );
 		}
 	}
 }
+
+// TestStringIndex tests that we handle UTF characters.
+func TestStringIndex(t *testing.T) {
+
+	type Test struct {
+		Input  string
+		Result bool
+	}
+
+	tests := []Test{
+		{Input: `return( "Hachikō"[6] == "ō" );`, Result: true},
+	}
+
+	for _, tst := range tests {
+
+		obj := New(tst.Input)
+
+		p := obj.Prepare()
+		if p != nil {
+			t.Fatalf("Failed to compile")
+		}
+
+		ret, err := obj.Run(nil)
+		if err != nil {
+			t.Fatalf("Found unexpected error running test '%s' - %s\n", tst.Input, err.Error())
+		}
+
+		if ret != tst.Result {
+			t.Fatalf("Found unexpected result running script")
+		}
+	}
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/skx/evalfilter/v2/code"
 	"github.com/skx/evalfilter/v2/environment"
@@ -1179,11 +1180,21 @@ func (vm *VM) executeIndexExpression(left, index object.Object) error {
 	if left.Type() == object.STRING {
 
 		str := left.(*object.String).Inspect()
-		if idx < 0 || int(idx) > len(str) {
+
+		// Count the characters
+		len := utf8.RuneCountInString(str)
+		if idx < 0 || int(idx) > len {
 			vm.stack.Push(Null)
 			return nil
 		}
-		vm.stack.Push(&object.String{Value: string(str[idx])})
+
+		// Get the characters as an array of runes
+		chars := []rune(str)
+
+		// Now index
+		val := &object.String{Value: string(chars[idx])}
+
+		vm.stack.Push(val)
 		return nil
 	}
 


### PR DESCRIPTION
Manual inspection, when I was implementing string-iteration, revelead that string-indexing was broken for multi-byte characters.

This pull-request will fix it when complete, and closes #118.