### PR TITLE
Bounds-check some of our bytecode

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -426,7 +426,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			ip = opArg - opLen
 
 			if opArg >= len(vm.bytecode) {
-				return nil, fmt.Errorf("Instruction pointer is out of bounds")
+				return nil, fmt.Errorf("instruction pointer is out of bounds")
 			}
 
 			// flow-control: jump if stack contains non-true
@@ -448,7 +448,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 				ip = opArg - opLen
 
 				if opArg >= len(vm.bytecode) {
-					return nil, fmt.Errorf("Instruction pointer is out of bounds")
+					return nil, fmt.Errorf("instruction pointer is out of bounds")
 				}
 			}
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -113,6 +113,10 @@ func New(constants []object.Object, bytecode code.Instructions, functions map[st
 		functions:   functions,
 	}
 
+	// Set a default context
+	ctx := context.Background()
+	vm.SetContext(ctx)
+
 	// Optimize the bytecode, if we should.
 	if optimize {
 
@@ -260,11 +264,19 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			// Lookup variable/field, by name
 		case code.OpConstant:
 
+			if opArg >= len(vm.constants) {
+				return nil, fmt.Errorf("access to constant which doesn't exist")
+			}
+
 			// move the contents of a constant onto the stack
 			vm.stack.Push(vm.constants[opArg])
 
 			// Lookup variable/field, by name
 		case code.OpLookup:
+
+			if opArg >= len(vm.constants) {
+				return nil, fmt.Errorf("access to constant which doesn't exist")
+			}
 
 			// Get the name.
 			name := vm.constants[opArg].Inspect()
@@ -413,6 +425,10 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 
 			ip = opArg - opLen
 
+			if opArg >= len(vm.bytecode) {
+				return nil, fmt.Errorf("Instruction pointer is out of bounds")
+			}
+
 			// flow-control: jump if stack contains non-true
 		case code.OpJumpIfFalse:
 
@@ -430,6 +446,10 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 				// it again..
 
 				ip = opArg - opLen
+
+				if opArg >= len(vm.bytecode) {
+					return nil, fmt.Errorf("Instruction pointer is out of bounds")
+				}
 			}
 
 			// function-call: This is messy.
@@ -679,6 +699,11 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			// Increment the value of an object, by name, if the Increment
 			// interface is implemented by it.
 		case code.OpInc:
+
+			if opArg >= len(vm.constants) {
+				return nil, fmt.Errorf("access to constant which doesn't exist")
+			}
+
 			// Get the name of the variable whos' contents
 			// we should increment.
 			name := vm.constants[opArg].Inspect()
@@ -705,6 +730,11 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			// Decrement the value of an object, by name, if the Decrement
 			// interface is implemented by it.
 		case code.OpDec:
+
+			if opArg >= len(vm.constants) {
+				return nil, fmt.Errorf("access to constant which doesn't exist")
+			}
+
 			// Get the name of the variable whos' contents
 			// we should decrement.
 			name := vm.constants[opArg].Inspect()

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -953,7 +953,7 @@ func TestOpJumpIfFalse(t *testing.T) {
 				byte(code.OpFalse),       // 0x06
 				byte(code.OpReturn),      // 0x07
 			},
-			result: "Instruction pointer is out of bounds",
+			result: "instruction pointer is out of bounds",
 			error:  true,
 		},
 		// OpJump
@@ -964,7 +964,7 @@ func TestOpJumpIfFalse(t *testing.T) {
 				byte(11),            // 0x03
 				byte(code.OpReturn), // 0x07
 			},
-			result: "Instruction pointer is out of bounds",
+			result: "instruction pointer is out of bounds",
 			error:  true,
 		},
 	}


### PR DESCRIPTION
This pull-request adds bounds-checking to some of our opcodes, which closes #135.

* OpConstant
* OpLookup
* OpJump
* OpJumpIfFalse

Also default to setting up a context if none is supplied.

I was going to add a verifier, but there are actually so few opcodes that take a parameter which can be abused that it didn't make sense to do this once - instead we do it at runtime, even if there is a minor speed-hit.