### PR TITLE
Remove functions that are never called.

### DIFF
--- a/vm/optimizer.go
+++ b/vm/optimizer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/skx/evalfilter/v2/code"
+	"github.com/skx/evalfilter/v2/object"
 )
 
 // optimize optimizes our bytecode by working over the program
@@ -61,6 +62,9 @@ func (vm *VM) optimizeBytecode() int {
 
 	// Finally kill dead code
 	vm.removeDeadCode()
+
+	// Remove functions that aren't called.
+	vm.optimizeFunctions()
 
 	// And return the changes.
 	return (sz - len(vm.bytecode))
@@ -625,5 +629,95 @@ func (vm *VM) removeDeadCode() {
 	//
 	if changed {
 		vm.bytecode = tmp
+	}
+}
+
+// optimizeFunctions - removes functions that aren't called.
+//
+// The key observation here is that to make a call we generate bytecode
+// to setup the stack like so:
+//
+//    arg1
+//    arg2
+//    arg3
+//    ..
+//    argN
+//    OpConstant "print"
+//    OpCall N
+//
+// So we can look at our bytecode to find functions that are called by
+// looking for "OpConstant XXXX" immediately prior to "OpCall NN".
+func (vm *VM) optimizeFunctions() {
+
+	// Keep track of functions which are called here.
+	called := make(map[string]bool)
+
+	// The previous OpConstant value we've found, if any.
+	//
+	// We're looking for OpConstant followed by OpCall.
+	var prev object.Object
+
+	// Walk the main script.
+	vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
+		switch opCode {
+
+		case code.OpConstant:
+			// Save any constant away
+			prev = vm.constants[opArg.(int)]
+		case code.OpCall:
+			// If we got an OpCall instruction then
+			// use the previous constant.
+			if prev != nil {
+				called[prev.Inspect()] = true
+			}
+			prev = nil
+		default:
+			// Any other instruction?  Remove the saved value.
+			prev = nil
+		}
+		return true, nil
+	})
+
+	// Reset to a known-state.
+	prev = nil
+
+	// Now we need to examine every function that has been
+	// defined.
+	for name := range vm.functions {
+
+		vm.WalkFunctionBytecode(name, func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
+			switch opCode {
+
+			case code.OpConstant:
+				// Save the constant away
+				prev = vm.constants[opArg.(int)]
+			case code.OpCall:
+				// If we got an OpCall instruction then
+				// use the previous constant.
+				if prev != nil {
+					called[prev.Inspect()] = true
+				}
+				prev = nil
+			default:
+				// Any other instruction?
+				// Remove the saved value.
+				prev = nil
+			}
+			return true, nil
+		})
+	}
+
+	//
+	// Now we have `vm.functions` containing all functions.
+	//
+	// And `called` containing those functions which were
+	// called.
+	//
+	for name, _ := range vm.functions {
+
+		// Not called?  Delete it.
+		if !called[name] {
+			delete(vm.functions, name)
+		}
 	}
 }

--- a/vm/optimizer.go
+++ b/vm/optimizer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/skx/evalfilter/v2/code"
+	"github.com/skx/evalfilter/v2/environment"
 	"github.com/skx/evalfilter/v2/object"
 )
 
@@ -710,14 +711,21 @@ func (vm *VM) optimizeFunctions() {
 	//
 	// Now we have `vm.functions` containing all functions.
 	//
-	// And `called` containing those functions which were
-	// called.
+	// And `called` containing those functions which were called.
 	//
-	for name := range vm.functions {
-
-		// Not called?  Delete it.
-		if !called[name] {
-			delete(vm.functions, name)
+	// Copy those that were called into a temporary map, then
+	// switch it over.
+	//
+	tmp := make(map[string]environment.UserFunction)
+	for name, fun := range vm.functions {
+		_, ok := called[name]
+		if !ok {
+			continue
+		}
+		if called[name] {
+			tmp[name] = fun
 		}
 	}
+	vm.functions = tmp
+
 }

--- a/vm/optimizer.go
+++ b/vm/optimizer.go
@@ -713,7 +713,7 @@ func (vm *VM) optimizeFunctions() {
 	// And `called` containing those functions which were
 	// called.
 	//
-	for name, _ := range vm.functions {
+	for name := range vm.functions {
 
 		// Not called?  Delete it.
 		if !called[name] {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -123,15 +123,12 @@ func New(constants []object.Object, bytecode code.Instructions, functions map[st
 		// Run the optimization, which will return the
 		// number of bytecode instructions "saved" or
 		// reduced/removed.
-		saved := vm.optimizeBytecode()
-
-		if debug && optimize {
-			fmt.Printf("Bytecode optimizer saved %d bytes\n", saved)
-		}
+		vm.optimizeBytecode()
 
 		//
 		// Now functions
 		//
+		tmp := make(map[string]environment.UserFunction)
 		for name, fun := range functions {
 
 			// Save the main bytecode away
@@ -147,16 +144,14 @@ func New(constants []object.Object, bytecode code.Instructions, functions map[st
 				fmt.Printf("Bytecode optimizer saved %d bytes for function %s\n", saved, name)
 			}
 
-			// Now update the function's bytecode
-			//
-			// This will show the savings.
-			x := vm.functions[name]
-			x.Bytecode = vm.bytecode
-			vm.functions[name] = x
+			// Save it away
+			fun.Bytecode = vm.bytecode
+			tmp[name] = fun
 
 			// And reset the saved vm-bytecode
 			vm.bytecode = safe
 		}
+		vm.functions = tmp
 	}
 
 	return vm


### PR DESCRIPTION
This commit removes functions which are not called, in an attempt
at optimization.  Honestly there will be no runtime difference,
but it feels like the right thing to do.

Given this input:

```
function foo() {
  foreach char in "Steve" {
   printf( "Char: %s\n", char );
  }
}

// foo();
return false;
```

Our generated bytecode is `OpFalse; OpReturn`, and there are no
references to the function `foo` at all.

This closes #140.

However the constants are still present, which is tracked in #141:

```
$ go build . && ./evalfilter bytecode ./t.in
Bytecode:
  0000	       OpFalse
  0001	      OpReturn

Constant Pool:
  0000 Type:STRING Value:"Steve"
  0001 Type:STRING Value:""
  0002 Type:STRING Value:"char"
  0003 Type:STRING Value:"Char: %s\n"
  0004 Type:STRING Value:"printf"
```