### PR TITLE
A terminating return-result is not mandatory.

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -794,12 +794,11 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 	// If we get here we've hit the end of the bytecode, and we
 	// didn't encounter a return-instruction.
 	//
-	// That means the script is malformed..
+	// In the case where a user is running the script as a filter
+	// then a missing return code is probably going to be treated
+	// as a "false" return.  But the caller can decide that.
 	//
-	// We could decide this means the script returns `false`, but
-	// I'd rather users were explicit.
-	//
-	return nil, fmt.Errorf("missing return at the end of the script")
+	return Null, nil
 }
 
 // inspectObject discovers the names/values of all structure fields, or

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -181,8 +181,8 @@ func TestMissingReturn(t *testing.T) {
 				byte(code.OpTrue),
 				byte(code.OpFalse),
 			},
-			result: "missing return",
-			error:  true,
+			result: "null",
+			error:  false,
 		},
 	}
 


### PR DESCRIPTION
This makes the interpreter more flexible for embedded users.

Closes #147.