### PR TITLE
146 switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     * [Conditionals](#conditionals)
     * [Loops](#loops)
     * [Functions](#functions)
-    * [Case/Switch](#switch--case)
+    * [Case/Switch](#case--switch)
   * [Use Cases](#use-cases)
   * [Security](#security)
     * [Denial of service](#denial-of-service)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     * [Conditionals](#conditionals)
     * [Loops](#loops)
     * [Functions](#functions)
-    * [Switch/Case](#switch-case)
+    * [Case/Switch](#switch--case)
   * [Use Cases](#use-cases)
   * [Security](#security)
     * [Denial of service](#denial-of-service)
@@ -216,7 +216,7 @@ You can declare functions, for example:
 See [_examples/scripts/scope.in](_examples/scripts/scope.in) for another brief example, and discussion of scopes.
 
 
-### Switch / Case
+### Case / Switch
 
 We support the use of `switch` and `case` to simplify the handling of some control-flow.  An example would look like this:
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ See [_examples/scripts/scope.in](_examples/scripts/scope.in) for another brief e
 
 We support the use of `switch` and `case` to simplify the handling of some control-flow.  An example would look like this:
 
-   switch( Subject ) {
+    switch( Subject ) {
       case /^Re:/i {
          printf("Reply\n");
       }
@@ -236,7 +236,7 @@ We support the use of `switch` and `case` to simplify the handling of some contr
       default {
          printf("New message!\n");
       }
-   }
+    }
 
 Note that the `case` expression supports:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The scripting-language this package presents supports the basic types you'd expe
 * Arrays.
 * Floating-point numbers.
 * Integers.
+* Regular expressions.
 * Strings.
 * Time / Date values.
   * i.e. We can use reflection to handle `time.Time` values in any structure/map we're operating upon.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     * [Conditionals](#conditionals)
     * [Loops](#loops)
     * [Functions](#functions)
+    * [Switch/Case](#switch-case)
   * [Use Cases](#use-cases)
   * [Security](#security)
     * [Denial of service](#denial-of-service)
@@ -213,6 +214,38 @@ You can declare functions, for example:
     return false;
 
 See [_examples/scripts/scope.in](_examples/scripts/scope.in) for another brief example, and discussion of scopes.
+
+
+### Switch / Case
+
+We support the use of `switch` and `case` to simplify the handling of some control-flow.  An example would look like this:
+
+   switch( Subject ) {
+      case /^Re:/i {
+         printf("Reply\n");
+      }
+      case /^fwd:/i {
+         printf("Forwarded message\n");
+      }
+      case "DEAR" + "  " + WINNER" {
+         printf("SPAM\n");
+      }
+      case "YOU HAVE WON" {
+         printf("SPAM\n");
+      }
+      default {
+         printf("New message!\n");
+      }
+   }
+
+Note that the `case` expression supports:
+
+* Expression matches.
+* Literal matches.
+* Regular expression matches.
+
+To avoid fall-through-related bugs we've explicitly designed the case-statements to take _blocks_ as arguments, rather than statements.
+
 
 
 ## Use Cases

--- a/ast/ast_switch.go
+++ b/ast/ast_switch.go
@@ -1,0 +1,82 @@
+package ast
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/skx/evalfilter/v2/token"
+)
+
+// CaseExpression handles the case within a switch statement
+type CaseExpression struct {
+	// Token is the actual token
+	Token token.Token
+
+	// Default branch?
+	Default bool
+
+	// The thing we match
+	Expr []Expression
+
+	// The code to execute if there is a match
+	Block *BlockStatement
+}
+
+func (ce *CaseExpression) expressionNode() {}
+
+// TokenLiteral returns the literal token.
+func (ce *CaseExpression) TokenLiteral() string { return ce.Token.Literal }
+
+// String returns this object as a string.
+func (ce *CaseExpression) String() string {
+	var out bytes.Buffer
+
+	if ce.Default {
+		out.WriteString("default ")
+	} else {
+		out.WriteString("case ")
+
+		tmp := []string{}
+		for _, exp := range ce.Expr {
+			tmp = append(tmp, exp.String())
+		}
+		out.WriteString(strings.Join(tmp, ","))
+	}
+	out.WriteString(ce.Block.String())
+	return out.String()
+}
+
+// SwitchExpression handles a switch statement
+type SwitchExpression struct {
+	// Token is the actual token
+	Token token.Token
+
+	// Value is the thing that is evaluated to determine
+	// which block should be executed.
+	Value Expression
+
+	// The branches we handle
+	Choices []*CaseExpression
+}
+
+func (se *SwitchExpression) expressionNode() {}
+
+// TokenLiteral returns the literal token.
+func (se *SwitchExpression) TokenLiteral() string { return se.Token.Literal }
+
+// String returns this object as a string.
+func (se *SwitchExpression) String() string {
+	var out bytes.Buffer
+	out.WriteString("\nswitch (")
+	out.WriteString(se.Value.String())
+	out.WriteString(")\n{\n")
+
+	for _, tmp := range se.Choices {
+		if tmp != nil {
+			out.WriteString(tmp.String())
+		}
+	}
+	out.WriteString("}\n")
+
+	return out.String()
+}

--- a/code/code.go
+++ b/code/code.go
@@ -69,6 +69,9 @@ const (
 	// Push a VOID value onto the stack.
 	OpVoid
 
+	// Pop a value from the stack
+	OpPop
+
 	// Run a case-comparison
 	OpCase
 
@@ -223,6 +226,7 @@ var OpCodeNames = [...]string{
 	OpNotEqual:       "OpNotEqual",
 	OpNotMatches:     "OpNotMatches",
 	OpOr:             "OpOr",
+	OpPop:            "OpPop",
 	OpPower:          "OpPower",
 	OpPush:           "OpPush",
 	OpRange:          "OpRange",

--- a/code/code.go
+++ b/code/code.go
@@ -69,6 +69,9 @@ const (
 	// Push a VOID value onto the stack.
 	OpVoid
 
+	// Run a case-comparison
+	OpCase
+
 	// Pop two values from the stack, add them, and push the result.
 	OpAdd
 
@@ -194,6 +197,7 @@ var OpCodeNames = [...]string{
 	OpArrayIn:        "OpArrayIn",
 	OpBang:           "OpBang",
 	OpCall:           "OpCall",
+	OpCase:           "OpCase",
 	OpConstant:       "OpConstant",
 	OpDec:            "OpDec",
 	OpDiv:            "OpDiv",

--- a/compiler.go
+++ b/compiler.go
@@ -635,6 +635,9 @@ func (e *Eval) compile(node ast.Node) error {
 
 				// finally the block
 				err = e.compile(opt.Block)
+				if err != nil {
+					return err
+				}
 
 				// now we know the end of the block.
 				e.changeOperand(pos, len(e.instructions))

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -284,10 +284,10 @@ func TestContains(t *testing.T) {
 	}
 
 	tests := []Test{
-		{Input: `if ( Greeting ~= "World" ) { return true; } return false;`, Result: true},
-		{Input: `if ( Greeting ~= "Moi" ) { return true; } return false;`, Result: false},
-		{Input: `if ( Greeting !~ "Cake" ) { return true; } return false;`, Result: true},
-		{Input: `if ( Greeting ~= "Cake" ) { return true; } return false;`, Result: false},
+		{Input: `if ( Greeting ~= /World/ ) { return true; } return false;`, Result: true},
+		{Input: `if ( Greeting ~= /Moi/ ) { return true; } return false;`, Result: false},
+		{Input: `if ( Greeting !~ /Cake/ ) { return true; } return false;`, Result: true},
+		{Input: `if ( Greeting ~= /Cake/ ) { return true; } return false;`, Result: false},
 	}
 
 	for _, tst := range tests {

--- a/example_switch_statement_test.go
+++ b/example_switch_statement_test.go
@@ -1,0 +1,97 @@
+package evalfilter
+
+import (
+	"fmt"
+)
+
+// ExampleSwitchFunction demonstrates how the case/switch statement
+// in our scripting language works.
+//
+func ExampleSwitchFunction() {
+
+	//
+	// We'll run this script, which defines a function and uses
+	// it.
+	//
+	//
+	script := `
+
+function test( name ) {
+
+  switch( name ) {
+    case "Ste" + "ve" {
+	printf("\tI know you - expression-match!\n" );
+    }
+    case "Steven" {
+	printf("\tI know you - literal-match!\n" );
+    }
+    case /steve kemp/i {
+        printf("\tI know you - regexp-match!\n");
+    }
+    default {
+	printf("\tDefault: I don't know who you are\n" );
+    }
+  }
+}
+
+printf("Running: Steve\n");
+test( "Steve" );
+
+printf("Running: Steven\n");
+test( "Steven" );
+
+printf("Running: steve kemp\n");
+test( "steve kemp" );
+
+printf("Running: bob\n");
+test( "Bob" );
+
+printf("Testing is all over\n")
+`
+
+	//
+	// Create the evaluator
+	//
+	eval := New(script)
+
+	//
+	// Prepare the evaluator.
+	//
+	err := eval.Prepare()
+	if err != nil {
+		fmt.Printf("Failed to compile the code:%s\n", err.Error())
+		return
+	}
+
+	//
+	// Call the filter - since we're testing
+	// the user-defined function we don't
+	// care about passing a real-object to it.
+	//
+	res, err := eval.Run(nil)
+
+	//
+	// Error-detection is important (!)
+	//
+	if err != nil {
+		panic(err)
+	}
+
+	//
+	// Show the output of the call.
+	//
+	if res {
+		fmt.Printf("%v\n", res)
+	}
+
+	// Output:
+	// Running: Steve
+	//	I know you - expression-match!
+	//Running: Steven
+	//	I know you - literal-match!
+	//Running: steve kemp
+	//	I know you - regexp-match!
+	//Running: bob
+	//	Default: I don't know who you are
+	//Testing is all over
+}

--- a/example_switch_statement_test.go
+++ b/example_switch_statement_test.go
@@ -4,6 +4,19 @@ import (
 	"fmt"
 )
 
+// SwitchFunction is just a temporary structure.
+//
+// Without this the following error occurs when linting this code:
+//
+//
+//   $ go vet ./...
+//   # github.com/skx/evalfilter/v2
+//   ./example_switch_statement_test.go:16:1: ExampleSwitchFunction refers to unknown identifier: SwitchFunction
+//
+type SwitchFunction struct {
+	foo string
+}
+
 // ExampleSwitchFunction demonstrates how the case/switch statement
 // in our scripting language works.
 //

--- a/example_switch_statement_test.go
+++ b/example_switch_statement_test.go
@@ -22,6 +22,10 @@ type SwitchFunction struct {
 //
 func ExampleSwitchFunction() {
 
+	// Ignore this - just to resolve the linter warning
+	x := SwitchFunction{}
+	x.foo = "bar"
+
 	//
 	// We'll run this script, which defines a function and uses
 	// it.

--- a/object/object.go
+++ b/object/object.go
@@ -9,6 +9,7 @@
 // * Integer number.
 // * Null
 // * String value.
+// * Regular-expression objects.
 //
 // To allow these objects to be used interchanagably each kind of object
 // must implement the same simple interface.
@@ -27,6 +28,7 @@ const (
 	FLOAT   = "FLOAT"
 	INTEGER = "INTEGER"
 	NULL    = "NULL"
+	REGEXP  = "REGEXP"
 	STRING  = "STRING"
 	VOID    = "VOID"
 )

--- a/object/object_regexp.go
+++ b/object/object_regexp.go
@@ -1,0 +1,35 @@
+package object
+
+// Regexp wraps string and implements the Object interface.
+type Regexp struct {
+	// Value holds the string value this object wraps.
+	Value string
+
+	// Offset holds our iteration-offset
+	offset int
+}
+
+// Type returns the type of this object.
+func (r *Regexp) Type() Type {
+	return REGEXP
+}
+
+// Inspect returns a string-representation of the given object.
+func (r *Regexp) Inspect() string {
+	return r.Value
+}
+
+// True returns whether this object wraps a true-like value.
+//
+// Used when this object is the conditional in a comparison, etc.
+func (r *Regexp) True() bool {
+	return (r.Value != "")
+}
+
+// ToInterface converts this object to a go-interface, which will allow
+// it to be used naturally in our sprintf/printf primitives.
+//
+// It might also be helpful for embedded users.
+func (r *Regexp) ToInterface() interface{} {
+	return r.Value
+}

--- a/object/object_regexp.go
+++ b/object/object_regexp.go
@@ -3,10 +3,9 @@ package object
 // Regexp wraps string and implements the Object interface.
 type Regexp struct {
 	// Value holds the string value this object wraps.
+	//
+	// (Yes we're a regexp, but we pretend we're string!)
 	Value string
-
-	// Offset holds our iteration-offset
-	offset int
 }
 
 // Type returns the type of this object.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -474,6 +474,10 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 
 				}
 			}
+		} else {
+			// error - unexpected token
+			p.errors = append(p.errors, fmt.Sprintf("expected case|default, got %s around position %s", p.curToken.Type, p.curToken.Position()))
+			return nil
 		}
 
 		if !p.expectPeek(token.LBRACE) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -514,7 +514,7 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 		}
 	}
 	if count > 1 {
-		msg := fmt.Sprintf("A switch-statement should only have one default block")
+		msg := "A switch-statement should only have one default block"
 		p.errors = append(p.errors, msg)
 		return nil
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -147,6 +147,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.SQRT, p.parsePrefixExpression)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
 	p.registerPrefix(token.TRUE, p.parseBooleanLiteral)
+	p.registerPrefix(token.SWITCH, p.parseSwitchStatement)
 	p.registerPrefix(token.WHILE, p.parseWhileStatement)
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
@@ -405,6 +406,121 @@ func (p *Parser) parseFloatLiteral() ast.Expression {
 	}
 	flo.Value = value
 	return flo
+}
+
+// parseSwitchStatement handles a switch statement
+func (p *Parser) parseSwitchStatement() ast.Expression {
+
+	// switch
+	expression := &ast.SwitchExpression{Token: p.curToken}
+
+	// look for (xx)
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	expression.Value = p.parseExpression(LOWEST)
+	if expression.Value == nil {
+		return nil
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+
+	// Now we have a block containing blocks.
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	p.nextToken()
+
+	// Process the block which we think will contain
+	// various case-statements
+	for !p.curTokenIs(token.RBRACE) {
+
+		if p.curTokenIs(token.EOF) {
+			p.errors = append(p.errors, "unterminated switch statement")
+			return nil
+		}
+		tmp := &ast.CaseExpression{Token: p.curToken}
+
+		// Default will be handled specially
+		if p.curTokenIs(token.DEFAULT) {
+
+			// We have a default-case here.
+			tmp.Default = true
+
+		} else if p.curTokenIs(token.CASE) {
+
+			// skip "case"
+			p.nextToken()
+
+			// Here we allow "case default" even though
+			// most people would prefer to write "default".
+			if p.curTokenIs(token.DEFAULT) {
+				tmp.Default = true
+			} else {
+
+				// parse the match-expression.
+				tmp.Expr = append(tmp.Expr, p.parseExpression(LOWEST))
+				for p.peekTokenIs(token.COMMA) {
+
+					// skip the comma
+					p.nextToken()
+
+					// setup the expression.
+					p.nextToken()
+
+					tmp.Expr = append(tmp.Expr, p.parseExpression(LOWEST))
+
+				}
+			}
+		}
+
+		if !p.expectPeek(token.LBRACE) {
+
+			msg := fmt.Sprintf("expected token to be '{', got %s instead", p.curToken.Type)
+			p.errors = append(p.errors, msg)
+			fmt.Printf("error\n")
+			return nil
+		}
+
+		// parse the block
+		tmp.Block = p.parseBlockStatement()
+
+		if !p.curTokenIs(token.RBRACE) {
+			msg := fmt.Sprintf("Syntax Error: expected token to be '}', got %s instead", p.curToken.Type)
+			p.errors = append(p.errors, msg)
+			fmt.Printf("error\n")
+			return nil
+
+		}
+		p.nextToken()
+
+		// save the choice away
+		expression.Choices = append(expression.Choices, tmp)
+
+	}
+
+	// ensure we're at the the closing "}"
+	if !p.curTokenIs(token.RBRACE) {
+		return nil
+	}
+
+	// More than one default is a bug
+	count := 0
+	for _, c := range expression.Choices {
+		if c.Default {
+			count++
+		}
+	}
+	if count > 1 {
+		msg := fmt.Sprintf("A switch-statement should only have one default block")
+		p.errors = append(p.errors, msg)
+		return nil
+
+	}
+	return expression
+
 }
 
 // parseBoolean parses a boolean token.

--- a/token/token.go
+++ b/token/token.go
@@ -40,9 +40,11 @@ const (
 	ASTERISK       = "*"
 	ASTERISKEQUALS = "*="
 	BANG           = "!"
+	CASE           = "case"
 	COLON          = ":"
 	COMMA          = ","
 	CONTAINS       = "~="
+	DEFAULT        = "DEFAULT"
 	DOTDOT         = ".."
 	ELSE           = "ELSE"
 	EOF            = "EOF"
@@ -88,12 +90,15 @@ const (
 	SLASHEQUALS    = "/="
 	SQRT           = "√"
 	STRING         = "STRING"
+	SWITCH         = "switch"
 	TRUE           = "TRUE"
 	WHILE          = "WHILE"
 )
 
 // reversed keywords
 var keywords = map[string]Type{
+	"case":     CASE,
+	"default":  DEFAULT,
 	"else":     ELSE,
 	"false":    FALSE,
 	"for":      FOR,
@@ -103,6 +108,7 @@ var keywords = map[string]Type{
 	"in":       IN,
 	"local":    LOCAL,
 	"return":   RETURN,
+	"switch":   SWITCH,
 	"true":     TRUE,
 	"while":    WHILE,
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -386,6 +386,25 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			arr := &object.Array{Elements: elements}
 			vm.stack.Push(arr)
 
+			// Case statement
+		case code.OpCase:
+			caseVal, err := vm.stack.Pop()
+			if err != nil {
+				return nil, err
+			}
+			val, err := vm.stack.Pop()
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO - regexp
+			if val.Type() == caseVal.Type() &&
+				(val.Inspect() == caseVal.Inspect()) {
+				vm.stack.Push(True)
+			} else {
+				vm.stack.Push(False)
+			}
+
 			// Array/String index
 		case code.OpIndex:
 			index, err := vm.stack.Pop()

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -462,6 +462,9 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 		case code.OpVoid:
 			vm.stack.Push(Void)
 
+		case code.OpPop:
+			vm.stack.Pop()
+
 			// Boolean literal
 		case code.OpFalse:
 			vm.stack.Push(False)


### PR DESCRIPTION
This pull-request will close #146, by adding support for switch-statements.

Currently:

* We can lex the new keywords `case`, `default`, & `switch`.
* We can parse those into an AST

The outstanding task is to generate bytecode for it.  This will likely need a new op-code.  When I implemented this support for [monkey](https://github.com/skx/monkey/) at run-time I handled two cases:

* Literals.
* Regexps.

Handling one or the other would use our existing opcodes.  It might be I need to define OP_CASE to handle either, as discovered dynamically.

It did cross my mind to cross compile a case statement into a series of `if` expressions, but that suffers from the same problem. 

TODO:

* Define a new opcode for matching.
* Use that to generate code, patching up offsets, etc.