### PR TITLE
Allow underscores in identifier names.

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -10,8 +10,10 @@ go get -u golang.org/x/lint/golint
 go get -u honnef.co/go/tools/cmd/staticcheck
 
 # Run the static-check tool
+#
+# Ignore ST1003 - "should not use underscores in Go names;
 t=$(mktemp)
-staticcheck -checks all ./... > $t
+staticcheck -checks all ./...  | grep -v ST1003 > $t
 if [ -s $t ]; then
     echo "Found errors via 'staticcheck'"
     cat $t

--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -23,14 +23,20 @@ fi
 rm $t
 
 
+# Run the linter-tool
+echo "Launching linter .."
+golint ./... | grep -v underscores > $t
+if [ -s $t ]; then
+    echo "Found errors via 'staticcheck'"
+    cat $t
+    rm $t
+    exit 1
+fi
+echo "Completed linter .."
+
 
 # At this point failures cause aborts
 set -e
-
-# Run the linter-tool
-echo "Launching linter .."
-golint -set_exit_status ./...
-echo "Completed linter .."
 
 # Run the vet-tool
 echo "Running go vet .."

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1357,3 +1357,44 @@ func TestMutators(t *testing.T) {
 		}
 	}
 }
+
+// Test identifiers can have underscores.
+func TestUnderscore(t *testing.T) {
+
+	// Dummy structure to test field-access.
+	type Structure struct {
+		foo_bar int
+	}
+
+	// Instance of object
+	var object Structure
+	object.foo_bar = 3
+
+	type Test struct {
+		Input  string
+		Result bool
+	}
+
+	tests := []Test{
+		{Input: `if ( foo_bar == 3 ) { return true; } return false;`, Result: true},
+	}
+
+	for _, tst := range tests {
+
+		obj := New(tst.Input)
+
+		p := obj.Prepare([]byte{NoOptimize})
+		if p != nil {
+			t.Fatalf("Failed to compile")
+		}
+
+		ret, err := obj.Run(object)
+		if err != nil {
+			t.Fatalf("Found unexpected error running test '%s' - %s\n", tst.Input, err.Error())
+		}
+
+		if ret != tst.Result {
+			t.Fatalf("Found unexpected result running script")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,4 @@ module github.com/skx/evalfilter/v2
 
 go 1.12
 
-require (
-	github.com/dvyukov/go-fuzz v0.0.0-20200916044129-21309f307f61 // indirect
-	github.com/elazarl/go-bindata-assetfs v1.0.1 // indirect
-	github.com/skx/subcommands v0.9.1
-	github.com/stephens2424/writerset v1.0.2 // indirect
-	golang.org/x/tools v0.0.0-20200925191224-5d1fdd8fa346 // indirect
-)
+require github.com/skx/subcommands v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/skx/subcommands v0.9.1 h1:9z5INLEDi3sFnUoY8qZWAnszfQYvyT2+Mo4Yj2TRzUo=
+github.com/skx/subcommands v0.9.1/go.mod h1:HpOZHVUXT5Rc/Q7UCiyj7h5u6BleDfFjt+vxy2igonA=

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -536,7 +536,7 @@ func (l *Lexer) peekChar() rune {
 // but they must start with a letter.  Here that works because we are only
 // called if the first character is alphabetical.
 func isIdentifier(ch rune) bool {
-	if unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '$' {
+	if unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '$' || ch == '_' {
 		return true
 	}
 	return false

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -757,3 +757,21 @@ func TestIllegal(t *testing.T) {
 		}
 	}
 }
+
+// TestIdentifier is designed to show we can handle identifiers.
+func TestIdentifiers(t *testing.T) {
+
+	valid := []string{"foo_bar", "$foo", "bar_"}
+
+	for _, input := range valid {
+		l := New(input)
+
+		tok := l.NextToken()
+		if tok.Type != token.IDENT {
+			t.Fatalf("token is not an identifier")
+		}
+		if tok.Literal != input {
+			t.Fatalf("token didn't have a literal match")
+		}
+	}
+}


### PR DESCRIPTION
This closes #158 by allowing underscores in the names of identifiers.