### PR TITLE
159 nested access

### DIFF
--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1363,12 +1363,12 @@ func TestUnderscore(t *testing.T) {
 
 	// Dummy structure to test field-access.
 	type Structure struct {
-		foo_bar int
+		Foo_Bar int
 	}
 
 	// Instance of object
 	var object Structure
-	object.foo_bar = 3
+	object.Foo_Bar = 3
 
 	type Test struct {
 		Input  string
@@ -1376,7 +1376,7 @@ func TestUnderscore(t *testing.T) {
 	}
 
 	tests := []Test{
-		{Input: `if ( foo_bar == 3 ) { return true; } return false;`, Result: true},
+		{Input: `if ( Foo_Bar == 3 ) { return true; } return false;`, Result: true},
 	}
 
 	for _, tst := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -536,7 +536,7 @@ func (l *Lexer) peekChar() rune {
 // but they must start with a letter.  Here that works because we are only
 // called if the first character is alphabetical.
 func isIdentifier(ch rune) bool {
-	if unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '$' || ch == '_' {
+	if unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '$' || ch == '.' || ch == '_' {
 		return true
 	}
 	return false

--- a/reflection/reflection.go
+++ b/reflection/reflection.go
@@ -1,0 +1,202 @@
+// Package reflection is the magic which lets us access members of
+// objects and structures by name.
+//
+// Given an input object of the form:
+//
+//   foo{
+//     bar {
+//      baz: "Steve"
+//     }
+//   }
+//
+// We can access that as `foo.bar.baz`.
+//
+// This is all a bit horrid, because we've tried to unify the handling by
+// first of all encoding the input-object to JSON, then decoding it again.
+//
+// The upshot is a working system though, for either objects or maps.
+package reflection
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/skx/evalfilter/v2/object"
+)
+
+// Reflection holds our state
+type Reflection struct {
+
+	// input is the object we're passed in our constructor
+	input interface{}
+
+	// fields contains the contents of all the fields in the object
+	// or map we're executing against.  We discover these via reflection
+	// at run-time.
+	//
+	// Reflection is slow so the map here is used as a cache, avoiding
+	// the need to reparse the same object multiple times.
+	fields map[string]object.Object
+
+	// Have we walked our object?
+	processed bool
+}
+
+// New creates a new helper which will inspect the fields of the given
+// structure, or object.
+func New(input interface{}) *Reflection {
+
+	r := &Reflection{
+		input:     input,
+		fields:    make(map[string]object.Object),
+		processed: false,
+	}
+
+	return r
+}
+
+// Get looks up the value from the parsed structure, based upon the name of
+// the field.
+func (r *Reflection) Get(key string) (object.Object, error) {
+
+	// Not processed?
+	if !r.processed {
+
+		// Then process.
+		e := r.Process()
+		if e != nil {
+			return &object.Null{}, fmt.Errorf("error processing for key %s - %s", key, e.Error())
+		}
+	}
+
+	// Lookup the key, if we found it return it.
+	val, ok := r.fields[key]
+	if ok {
+		return val, nil
+	}
+
+	// Otherwise we have an error
+	return &object.Null{}, fmt.Errorf("key not found '%s'", key)
+}
+
+// Process handles getting the fields of the input we were given, via
+// reflection and storing the values in a local cache.
+func (r *Reflection) Process() error {
+
+	// Already processed?  Then avoid a repeat
+	if r.processed {
+		return nil
+	} else {
+		r.processed = true
+	}
+
+	// Yeah, horrid.
+	data, err := json.Marshal(r.input)
+	if err != nil {
+		return err
+	}
+
+	// Now we have json.
+	//
+	// unmarshal
+	var obj interface{}
+	err = json.Unmarshal(data, &obj)
+	if err != nil {
+		return err
+	}
+
+	//
+	// Flatten and store
+	//
+	r.flatten(obj, "")
+
+	return nil
+}
+
+func (r *Reflection) flatten(obj interface{}, prefix string) {
+	switch obj := obj.(type) {
+	case bool:
+		r.fields[prefix] = &object.Boolean{Value: obj}
+	case int:
+		r.fields[prefix] = &object.Integer{Value: int64(obj)}
+	case int32:
+		r.fields[prefix] = &object.Integer{Value: int64(obj)}
+	case int64:
+		r.fields[prefix] = &object.Integer{Value: int64(obj)}
+	case float32:
+		// really an int?
+		if float32(int32(obj)) == obj {
+			r.fields[prefix] = &object.Integer{Value: int64(obj)}
+		} else {
+			r.fields[prefix] = &object.Float{Value: float64(obj)}
+		}
+	case time.Time:
+		r.fields[prefix] = &object.Integer{Value: interface{}(obj).(time.Time).Unix()}
+	case float64:
+		// really an int?
+		if float64(int64(obj)) == obj {
+			r.fields[prefix] = &object.Integer{Value: int64(obj)}
+		} else {
+			r.fields[prefix] = &object.Float{Value: float64(obj)}
+		}
+	case string:
+		r.fields[prefix] = &object.String{Value: obj}
+	case []interface{}:
+		var el []object.Object
+
+		for _, v := range obj {
+
+			var tmp object.Object
+
+			switch v := v.(type) {
+			case bool:
+				tmp = &object.Boolean{Value: v}
+			case int:
+				tmp = &object.Integer{Value: int64(v)}
+			case int32:
+				tmp = &object.Integer{Value: int64(v)}
+			case int64:
+				tmp = &object.Integer{Value: int64(v)}
+			case float32:
+				// really an int?
+				if float32(int32(v)) == v {
+					tmp = &object.Integer{Value: int64(v)}
+				} else {
+					tmp = &object.Float{Value: float64(v)}
+				}
+			case float64:
+				// really an int?
+				if float64(int64(v)) == v {
+					tmp = &object.Integer{Value: int64(v)}
+				} else {
+					tmp = &object.Float{Value: float64(v)}
+				}
+			case string:
+				tmp = &object.String{Value: v}
+			}
+
+			el = append(el, tmp)
+
+		}
+		r.fields[prefix] = &object.Array{Elements: el}
+
+	case map[string]interface{}:
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if len(prefix) > 0 {
+
+				r.flatten(obj[k], fmt.Sprintf("%s.%s", prefix, k))
+			} else {
+				r.flatten(obj[k], fmt.Sprintf("%s", k))
+			}
+		}
+	default:
+		fmt.Printf("%s = null\n", prefix)
+	}
+}

--- a/reflection/reflection_test.go
+++ b/reflection/reflection_test.go
@@ -1,0 +1,125 @@
+package reflection
+
+import (
+	"testing"
+
+	"github.com/skx/evalfilter/v2/object"
+)
+
+// TestBasic ensures our basic stuff is working
+func TestBasic(t *testing.T) {
+
+	type foo struct {
+		Name   string
+		Age    int
+		OK     bool
+		Number float32
+	}
+
+	obj := foo{Name: "Steve Kemp", Age: 42, Number: 3.25, OK: true}
+
+	r := New(obj)
+
+	//
+	// For each value we'll test we got something
+	//
+
+	// Name: String
+	nm, err := r.Get("Name")
+	if err != nil {
+		t.Fatalf("error getting name:%s", err.Error())
+	}
+	if nm.Type() != object.STRING {
+		t.Fatalf("wrong type")
+	}
+	if nm.Inspect() != "Steve Kemp" {
+		t.Fatalf("name is wrong")
+	}
+
+	// Age: Integer
+	age, err := r.Get("Age")
+	if err != nil {
+		t.Fatalf("error getting age")
+	}
+	if age.Type() != object.INTEGER {
+		t.Fatalf("wrong type, got: %s - %s", age.Type(), age.Inspect())
+	}
+	if age.Inspect() != "42" {
+		t.Fatalf("age is wrong")
+	}
+
+	// Number: Integer
+	n, err := r.Get("Number")
+	if err != nil {
+		t.Fatalf("error getting value")
+	}
+	if n.Type() != object.FLOAT {
+		t.Fatalf("wrong type")
+	}
+	if n.Inspect() != "3.25" {
+		t.Fatalf("number is wrong")
+	}
+
+	// OK: bool
+	b, err := r.Get("OK")
+	if err != nil {
+		t.Fatalf("error getting value")
+	}
+	if b.Type() != object.BOOLEAN {
+		t.Fatalf("wrong type")
+	}
+	if b.Inspect() != "true" {
+		t.Fatalf("bool is wrong")
+	}
+}
+
+// TestNested tries to test a nested structure.
+func TestNested(t *testing.T) {
+
+	type bar struct {
+		Value string
+	}
+	type foo struct {
+		Forename string
+		Surname  bar
+	}
+
+	obj := foo{Forename: "Steve", Surname: bar{Value: "Kemp"}}
+
+	r := New(obj)
+
+	// Name: String
+	sur, err := r.Get("Surname.Value")
+	if err != nil {
+		t.Fatalf("error getting value :%s", err.Error())
+	}
+	if sur.Type() != object.STRING {
+		t.Fatalf("wrong type")
+	}
+	if sur.Inspect() != "Kemp" {
+		t.Fatalf("wrong value")
+	}
+}
+
+func TestArray(t *testing.T) {
+
+	type Parent struct {
+		Name     string
+		Children []string
+	}
+
+	var dad Parent
+	dad.Name = "Homer"
+	dad.Children = []string{"Bart", "Lisa", "Maggie"}
+
+	r := New(dad)
+
+	// Children: String Array
+	c, err := r.Get("Children")
+	if err != nil {
+		t.Fatalf("error getting value :%s", err.Error())
+	}
+	if c.Type() != object.ARRAY {
+		t.Fatalf("wrong type, got %s", c.Type())
+	}
+}


### PR DESCRIPTION
This pull-request features a *major* rewrite of our reflection code, with the intention that we can access nested fields.

For example given the following `input.json`:

```
{
    "name": {
        "forename": "John",
        "surname": {
            "value": "Smith"
        }
    },
    "age":30
}
```

And the following script:

```

print( "The age is ", age, "\n" );
print( "The FORENAME is ", name.forename, "\n" );
print( "The SURENAME is ", name.surname.value, "\n" );

return false;
```


We can get the expected output:

```
go build . ; ./evalfilter run -json ../../_examples/scripts/on-call.json  ../../_examples/scripts/on-call.script 
The age is 30
The FORENAME is John
The SURENAME is Smith
Script gave result type:BOOLEAN value:false - which is 'false'.
```

This has only been lightly tested so far, but the existing test-cases continue to work so that's a reassuring sign.

The only caveat here is that we internally use JSON encoding and then decoding.  This causes two problems:

* Slower than reflection.
* Means private fields (i.e. lower-case member names) are ignored.

Whether those are problems will remain to be seen.

Closes #159.