### PR TITLE
Second attempt at nested fields

### DIFF
--- a/_examples/scripts/nested.json
+++ b/_examples/scripts/nested.json
@@ -1,0 +1,5 @@
+{ "Name":   { "Forename": "Steve",
+              "Surname": "Kemp",
+              "Address": { "Country": "Finland" }
+            }
+}

--- a/_examples/scripts/nested.script
+++ b/_examples/scripts/nested.script
@@ -1,0 +1,15 @@
+//
+// This is a script which is designed to demonstrate hash-access.
+//
+//     $ evalfilter run -json nested.json nested.script
+//
+// You'll notice that "Name.Forename" refers to a nested JSON object.
+//
+
+
+
+print( "Forename ", Name.Forename, "\n" );
+print( "Surname  ", Name.Surname,  "\n" );
+print( "Country  ", Name.Address.Country,  "\n" );
+
+return false;

--- a/compiler.go
+++ b/compiler.go
@@ -219,6 +219,9 @@ func (e *Eval) compile(node ast.Node) error {
 		case "in":
 			e.emit(code.OpArrayIn)
 
+		case ".":
+			e.emit(code.OpIndex)
+
 			// misc
 		case "..":
 			e.emit(code.OpRange)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -72,6 +72,7 @@ var precedences = map[token.Type]int{
 	token.OR:             COND,
 	token.LPAREN:         CALL,
 	token.LSQUARE:        INDEX,
+	token.PERIOD:         INDEX,
 }
 
 // Parser is the object which maintains our parser state.
@@ -164,6 +165,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.IN, p.parseInfixExpression)
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 	p.registerInfix(token.LSQUARE, p.parseIndexExpression)
+	p.registerInfix(token.PERIOD, p.parseInfixExpression)
 	p.registerInfix(token.LT, p.parseInfixExpression)
 	p.registerInfix(token.LTEQUALS, p.parseInfixExpression)
 	p.registerInfix(token.MINUS, p.parseInfixExpression)
@@ -570,6 +572,12 @@ func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 	precedence := p.curPrecedence()
 	p.nextToken()
 	expression.Right = p.parseExpression(precedence)
+
+	// hack
+	if expression.Operator == "." {
+		name := expression.Right.String()
+		expression.Right = &ast.StringLiteral{Token: token.Token{Type: token.STRING, Literal: name}, Value: name}
+	}
 
 	// If there was an error parsing the second operand
 	// then we must abort.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -915,6 +915,23 @@ func (vm *VM) inspectObject(obj interface{}) {
 			// Hack.
 			//
 			// Probably broken.
+			case reflect.Map:
+
+				hashedPairs := make(map[object.HashKey]object.HashPair)
+
+				for _, key := range field.MapKeys() {
+
+					k := &object.String{Value: fmt.Sprintf("%s", key)}
+
+					// The actual thing inside it
+					field := field.MapIndex(key).Elem()
+
+					v := &object.String{Value: fmt.Sprintf("%s", field)}
+
+					pair := object.HashPair{Key: k, Value: v}
+					hashedPairs[k.HashKey()] = pair
+				}
+				ret = &object.Hash{Pairs: hashedPairs}
 			case reflect.Slice:
 				ret = vm.createArrayFromSlice(field)
 			case reflect.Int, reflect.Int64:


### PR DESCRIPTION
This is a work in-progress which moves towards a simpler solution for nested field access.

The realization that we need to only handle the case of maps, and allow parsing them to our internal hash-objects.

If we have hash-objects parsed correctly then we can add the "." operator as a synonym, so these two lines of code are identical:

       foo["bar"]
       foo.bar

The initial commit makes that change, and followups will handle the parsing.

This replaces #161, and will close #159.