### PR TITLE
167 recover

### DIFF
--- a/environment/builtins.go
+++ b/environment/builtins.go
@@ -401,6 +401,17 @@ func fnType(args []object.Object) object.Object {
 	return &object.String{Value: val}
 }
 
+// fnPanic throws an error
+func fnPanic(args []object.Object) object.Object {
+
+	if len(args) == 1 {
+		panic(args[0].Inspect())
+	}
+
+	panic("panic!")
+	return &object.Void{}
+}
+
 // fnPrint is the implementation of our `print` function.
 func fnPrint(args []object.Object) object.Object {
 	for _, e := range args {

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -75,6 +75,7 @@ func New() *Environment {
 	env.SetFunction("max", fnMax)
 	env.SetFunction("min", fnMin)
 	env.SetFunction("now", fnNow)
+	env.SetFunction("panic", fnPanic)
 	env.SetFunction("print", fnPrint)
 	env.SetFunction("printf", fnPrintf)
 	env.SetFunction("reverse", fnReverse)

--- a/evalfilter.go
+++ b/evalfilter.go
@@ -251,7 +251,15 @@ func (e *Eval) Dump() error {
 //
 // Use of this method allows you to receive the `3` that a script
 // such as `return 1 + 2;` would return.
-func (e *Eval) Execute(obj interface{}) (object.Object, error) {
+func (e *Eval) Execute(obj interface{}) (out object.Object, error error) {
+
+	// Catch errors when we're executing.
+	defer func() {
+		if r := recover(); r != nil {
+			out = &object.Null{}
+			error = fmt.Errorf("error during Run: %s", r)
+		}
+	}()
 
 	//
 	// Launch the program in the VM.

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1399,3 +1399,40 @@ func TestUnderscore(t *testing.T) {
 		}
 	}
 }
+
+func TestPanic(t *testing.T) {
+	input := `
+
+panic("I'm a fish");
+return true ;
+`
+
+	obj := New(input)
+	err := obj.Prepare()
+	if err != nil {
+		t.Fatalf("Failed to compile")
+	}
+
+	_, err = obj.Run(nil)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "panic in Run") {
+		fmt.Printf("Wrong value")
+	}
+	if !strings.Contains(err.Error(), "fish") {
+		fmt.Printf("Wrong value")
+	}
+
+	_, err = obj.Execute(nil)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "panic in Run") {
+		fmt.Printf("Wrong value")
+	}
+	if !strings.Contains(err.Error(), "fish") {
+		fmt.Printf("Wrong value")
+	}
+
+}

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -135,38 +135,38 @@ func TestArrayIteration(t *testing.T) {
 // TestBoolean tests our Bool-object in a basic way.
 func TestBool(t *testing.T) {
 
-	true := &Boolean{Value: true}
-	false := &Boolean{Value: false}
+	tb := &Boolean{Value: true}
+	fb := &Boolean{Value: false}
 
 	// Inspect
-	if true.Inspect() != "true" {
+	if tb.Inspect() != "true" {
 		t.Fatalf("Invalid value!")
 	}
-	if false.Inspect() != "false" {
+	if fb.Inspect() != "false" {
 		t.Fatalf("Invalid value!")
 	}
 
 	// Type
-	if true.Type() != BOOLEAN {
+	if tb.Type() != BOOLEAN {
 		t.Fatalf("Wrong type")
 	}
-	if false.Type() != BOOLEAN {
+	if fb.Type() != BOOLEAN {
 		t.Fatalf("Wrong type")
 	}
 
 	// True
-	if !true.True() {
+	if !tb.True() {
 		t.Fatalf("Truth test on boolean failed")
 	}
-	if false.True() {
+	if fb.True() {
 		t.Fatalf("Truth test on boolean failed")
 	}
 
-	tX := true.ToInterface()
+	tX := tb.ToInterface()
 	if !tX.(bool) {
 		t.Fatalf("interface usage failed")
 	}
-	fX := false.ToInterface()
+	fX := fb.ToInterface()
 	if fX.(bool) {
 		t.Fatalf("interface usage failed")
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -764,15 +764,15 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 			}
 
 			// length
-			len := maxI - minI + 1
+			l := maxI - minI + 1
 
 			// holder for elements of the correct size
-			elements := make([]object.Object, len)
+			elements := make([]object.Object, l)
 
 			// Make the array
 			var i int64
 			i = 0
-			for i < len {
+			for i < l {
 				elements[i] = &object.Integer{Value: minI + i}
 				i++
 			}
@@ -1552,8 +1552,8 @@ func (vm *VM) executeIndexExpression(left, index object.Object) error {
 		str := left.(*object.String).Inspect()
 
 		// Count the characters
-		len := utf8.RuneCountInString(str)
-		if idx < 0 || int(idx) > len {
+		l := utf8.RuneCountInString(str)
+		if idx < 0 || int(idx) > l {
 			vm.stack.Push(Null)
 			return nil
 		}


### PR DESCRIPTION
This pull-request ensures that if any code calls `panic` during the course of execution we catch that and return a suitable error to the caller.

This is handled by adding a deferred `recover` handler to our `Run` method.

There's a new built-in `panic` which can be called:

* `panic()`
* `panic("Text goes here")`

This is used in the test-case to ensure that a panic can be caught.

This closes #167.