### PR TITLE
166 go routine

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -42,7 +42,7 @@ go vet ./...
 echo "Completed go vet .."
 
 # Run our golang tests
-go test ./...
+go test ./... -race
 
 # If that worked build our examples, to ensure they work
 # and that we've not broken compatibility

--- a/environment/builtins.go
+++ b/environment/builtins.go
@@ -402,14 +402,14 @@ func fnType(args []object.Object) object.Object {
 }
 
 // fnPanic throws an error
-func fnPanic(args []object.Object) object.Object {
+func fnPanic(args []object.Object) (out object.Object) {
 
+	out = &object.Void{}
 	if len(args) == 1 {
 		panic(args[0].Inspect())
 	}
 
 	panic("panic!")
-	return &object.Void{}
 }
 
 // fnPrint is the implementation of our `print` function.

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1470,17 +1470,19 @@ func TestRace(t *testing.T) {
 			jsonMap := make(map[string]interface{})
 			jsonErr := json.Unmarshal([]byte(line), &jsonMap)
 			if jsonErr != nil {
-				t.Fatalf("error decoding json")
+				t.Errorf("error decoding json")
 			}
 
 			_, err := obj.Run(jsonMap)
 			if err != nil {
-				t.Fatalf("Found unexpected error running test %s\n",
+				t.Errorf("Found unexpected error running test %s\n",
 					err.Error())
 			}
 
 			wg.Done()
+
 		}(input[i])
+
 	}
 
 	wg.Wait()


### PR DESCRIPTION
This pull-request closes #166, by adding an internal mutex around the `Run` method.

This allows multiple routines to call our evaluator safely.
