### PR TITLE
171 if else if else if

### DIFF
--- a/ast/ast_switch.go
+++ b/ast/ast_switch.go
@@ -42,7 +42,9 @@ func (ce *CaseExpression) String() string {
 
 		tmp := []string{}
 		for _, exp := range ce.Expr {
-			tmp = append(tmp, exp.String())
+			if exp != nil {
+				tmp = append(tmp, exp.String())
+			}
 		}
 		out.WriteString(strings.Join(tmp, ","))
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -700,6 +700,24 @@ func (p *Parser) parseIfExpression() ast.Expression {
 	}
 	if p.peekTokenIs(token.ELSE) {
 		p.nextToken()
+
+		// else if
+		if p.peekTokenIs(token.IF) {
+
+			p.nextToken()
+
+			expression.Alternative = &ast.BlockStatement{
+				Statements: []ast.Statement{
+					&ast.ExpressionStatement{
+						Expression: p.parseIfExpression(),
+					},
+				},
+			}
+
+			return expression
+		}
+
+		// else { block }
 		if !p.expectPeek(token.LBRACE) {
 			msg := fmt.Sprintf("expected { but got %s around %s", p.curToken.Literal, p.curToken.Position())
 			p.errors = append(p.errors, msg)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -856,6 +856,9 @@ func TestFuzzerResults(t *testing.T) {
 		`0.{0:{{0:{:0}}:0}}`,
 		`0.{0:{{0:!!{|:0}}:0}}`,
 		`0.-0.{�:0}`,
+		`0.switch(0){case�{}}`,
+		`0(0.switch(0){case{}}`,
+		`(0.switch(0){case{}}`,
 	}
 
 	for _, input := range inputs {


### PR DESCRIPTION
    Allow if-else-if-else-if
    
    This pull-request improves our parser to allow:
    
            if ( ) {
            } else if {
              ..
            } else if {
              ..
            } else {
              ..
            }
    
    This closes #171.

