### PR TITLE
173 json

### DIFF
--- a/cmd/evalfilter/run_cmd.go
+++ b/cmd/evalfilter/run_cmd.go
@@ -148,6 +148,19 @@ func (r *runCmd) Run(file string) {
 	fmt.Printf("Script gave result type:%s value:%s - which is '%t'.\n",
 		ret.Type(), ret.Inspect(), ret.True())
 
+	// Now show as JSON, if we can.
+	helper, ok := ret.(object.JSONAble)
+	if ok {
+
+		j, err := helper.JSON()
+		if err != nil {
+			fmt.Printf("Error converting result to JSON\n")
+			return
+		}
+
+		fmt.Printf("JSON Result:\n\t%s\n", j)
+	}
+
 }
 
 // Execute is invoked if the user specifies `run` as the subcommand.

--- a/object/object.go
+++ b/object/object.go
@@ -3,19 +3,21 @@
 //
 // Our scripting language supports several different object-types:
 //
-// * Array.
-// * Boolean value.
-// * Floating-point number.
-// * Integer number.
+// * Arrays.
+// * Boolean values.
+// * Floating-point numbers.
+// * Hashes.
+// * Integer numbers.
 // * Null
-// * String value.
+// * String values.
 // * Regular-expression objects.
 //
 // To allow these objects to be used interchanagably each kind of object
 // must implement the same simple interface.
 //
 // There are additional interfaces for adding support for more advanced
-// operations - such as iteration, incrementing, and decrementing.
+// operations - such as iteration, incrementing, decrementing, and JSON
+// export.
 package object
 
 // Type describes the type of an object.
@@ -80,6 +82,17 @@ type Decrement interface {
 	Decrease()
 }
 
+// JSONAble is an interface that some objects might wish to support.
+//
+// If this interface is implemented then it will be possible to export
+// the contents of a given object to JSON.
+type JSONAble interface {
+
+	// JSON will export this object to a JSON representation of
+	// the contents of the object.
+	JSON() (string, error)
+}
+
 // Iterable is an interface that some objects might wish to support.
 //
 // If this interface is implemented then it will be possible to
@@ -104,7 +117,10 @@ type Iterable interface {
 	Next() (Object, Object, bool)
 }
 
-// Hashable type can be hashed
+// Hashable type can be hashed.
+//
+// If an object-type implements this interface it can be used as
+// the key in one of our hash-objects.
 type Hashable interface {
 
 	// HashKey returns a hash key for the given object.

--- a/object/object_array.go
+++ b/object/object_array.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 )
 
@@ -73,5 +74,32 @@ func (ao *Array) Next() (Object, Object, bool) {
 	return nil, &Integer{Value: 0}, false
 }
 
+// JSON converts this object to a JSON string
+func (ao *Array) JSON() (string, error) {
+	var out bytes.Buffer
+	elements := make([]string, 0)
+	for _, e := range ao.Elements {
+
+		// Cast the value to a JSONAble interface
+		helper, ok := e.(JSONAble)
+		if !ok {
+			return "", fmt.Errorf("object doesn't implement JSONAble %s", e.Inspect())
+		}
+
+		// OK we can cast it, get the value
+		tmp, err := helper.JSON()
+		if err != nil {
+			return "", err
+		}
+
+		elements = append(elements, tmp)
+	}
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+	return out.String(), nil
+}
+
 // Ensure this object implements the expected interfaces
-var _ Iterable = &String{}
+var _ Iterable = &Array{}
+var _ JSONAble = &String{}

--- a/object/object_bool.go
+++ b/object/object_bool.go
@@ -32,3 +32,11 @@ func (b *Boolean) True() bool {
 func (b *Boolean) ToInterface() interface{} {
 	return b.Value
 }
+
+// JSON converts this object to a JSON string.
+func (b *Boolean) JSON() (string, error) {
+	return fmt.Sprintf("%t", b.Value), nil
+}
+
+// Ensure this object implements the expected interfaces.
+var _ JSONAble = &Integer{}

--- a/object/object_float.go
+++ b/object/object_float.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"fmt"
 	"hash/fnv"
 	"strconv"
 )
@@ -55,7 +56,13 @@ func (f *Float) HashKey() HashKey {
 	return HashKey{Type: f.Type(), Value: h.Sum64()}
 }
 
+// JSON converts this object to a JSON string.
+func (f *Float) JSON() (string, error) {
+	return fmt.Sprintf("%f", f.Value), nil
+}
+
 // Ensure this object implements the expected interfaces.
 var _ Decrement = &Float{}
 var _ Hashable = &Float{}
 var _ Increment = &Float{}
+var _ JSONAble = &Float{}

--- a/object/object_hash.go
+++ b/object/object_hash.go
@@ -129,5 +129,41 @@ func (h *Hash) ToInterface() interface{} {
 	return "<HASH>"
 }
 
+// JSON converts this object to a JSON string.
+func (h *Hash) JSON() (string, error) {
+
+	// Get the list of entries, sorted by key-name.
+	entries := h.Entries()
+
+	// Now output
+	var out bytes.Buffer
+
+	pairs := make([]string, 0)
+	for _, entry := range entries {
+
+		// Cast the value to a JSONAble interface
+		helper, ok := entry.Value.(JSONAble)
+		if !ok {
+			return "", fmt.Errorf("object doesn't implement JSONAble %s", entry.Value.Inspect())
+		}
+
+		// OK we can cast it, get the value
+		tmp, err := helper.JSON()
+		if err != nil {
+			return "", err
+		}
+
+		// Now build up the JSON
+		pairs = append(pairs, fmt.Sprintf("\"%s\": %s",
+			entry.Key.Inspect(), tmp))
+	}
+	out.WriteString("{")
+	out.WriteString(strings.Join(pairs, ", "))
+	out.WriteString("}")
+	return out.String(), nil
+
+}
+
 // Ensure this object implements the expected interfaces.
 var _ Iterable = &Hash{}
+var _ JSONAble = &Hash{}

--- a/object/object_int.go
+++ b/object/object_int.go
@@ -50,7 +50,13 @@ func (i *Integer) HashKey() HashKey {
 	return HashKey{Type: i.Type(), Value: uint64(i.Value)}
 }
 
+// JSON converts this object to a JSON string.
+func (i *Integer) JSON() (string, error) {
+	return fmt.Sprintf("%d", i.Value), nil
+}
+
 // Ensure this object implements the expected interfaces.
 var _ Decrement = &Integer{}
 var _ Hashable = &Integer{}
 var _ Increment = &Integer{}
+var _ JSONAble = &Integer{}

--- a/object/object_null.go
+++ b/object/object_null.go
@@ -34,4 +34,4 @@ func (n *Null) JSON() (string, error) {
 }
 
 // Ensure this object implements the expected interfaces.
-var _ JSONAble = &Integer{}
+var _ JSONAble = &Null{}

--- a/object/object_null.go
+++ b/object/object_null.go
@@ -27,3 +27,11 @@ func (n *Null) True() bool {
 func (n *Null) ToInterface() interface{} {
 	return nil
 }
+
+// JSON converts this object to a JSON string.
+func (n *Null) JSON() (string, error) {
+	return "null", nil
+}
+
+// Ensure this object implements the expected interfaces.
+var _ JSONAble = &Integer{}

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"hash/fnv"
+	"strconv"
 	"unicode/utf8"
 )
 
@@ -73,7 +74,7 @@ func (s *String) HashKey() HashKey {
 
 // JSON converts this object to a JSON string.
 func (s *String) JSON() (string, error) {
-	return "\"" + s.Value + "\"", nil
+	return strconv.Quote(s.Value), nil
 }
 
 // Ensure this object implements the expected interfaces

--- a/object/object_string.go
+++ b/object/object_string.go
@@ -71,6 +71,12 @@ func (s *String) HashKey() HashKey {
 	return HashKey{Type: s.Type(), Value: h.Sum64()}
 }
 
+// JSON converts this object to a JSON string.
+func (s *String) JSON() (string, error) {
+	return "\"" + s.Value + "\"", nil
+}
+
 // Ensure this object implements the expected interfaces
 var _ Hashable = &String{}
 var _ Iterable = &String{}
+var _ JSONAble = &String{}

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -648,7 +648,7 @@ func TestHashJSON(t *testing.T) {
 	dK := &String{Value: "Void"}
 	tmp.Pairs[dK.HashKey()] = d
 
-	str, err = tmp.JSON()
+	_, err = tmp.JSON()
 	if err == nil {
 		t.Fatalf("Expected error - due to void - didn't get one")
 	}
@@ -671,7 +671,7 @@ func TestHashJSON(t *testing.T) {
 	tmp.Pairs = make(map[HashKey]HashPair)
 	tmp.Pairs[aK.HashKey()] = a
 
-	str, err = tmp.JSON()
+	_, err = tmp.JSON()
 	if err == nil {
 		t.Fatalf("expected error, but got none")
 	}
@@ -716,7 +716,7 @@ func TestArrayJSON(t *testing.T) {
 	bad := &Array{Elements: broken}
 
 	// Export it
-	json, err = bad.JSON()
+	_, err = bad.JSON()
 
 	if err == nil {
 		t.Fatalf("Expected error - due to void - didn't get one")
@@ -729,7 +729,7 @@ func TestArrayJSON(t *testing.T) {
 	arr = &Array{Elements: content}
 
 	// Export it
-	json, err = arr.JSON()
+	_, err = arr.JSON()
 
 	if err == nil {
 		t.Fatalf("Expected error - due to void - didn't get one")

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -588,6 +588,18 @@ func TestStringJSON(t *testing.T) {
 	if aj != "\"Steve\"" {
 		t.Fatalf("Invalid value for string->JSON, got %s", aj)
 	}
+
+	b := &String{Value: "Name: \"Steve\""}
+	bj, bErr := b.JSON()
+
+	if bErr != nil {
+		t.Fatalf("Unexpected error")
+	}
+
+	exp := "\"Name: \\\"Steve\\\"\""
+	if bj != exp {
+		t.Fatalf("Invalid value for string->JSON, exp:%s\ngot:'%s'\n", exp, bj)
+	}
 }
 
 // Test converting a hash to JSON


### PR DESCRIPTION
This pull request, once complete, will allow users who embed this library in their application to export return values (and any other objects) to JSON-strings.

We do this by declaring a new interface `JSONAble` which contains a `JSON` method.

* If an object implements `JSONAble` you can call `JSON` upon it.
* Otherwise you cannot.

This closes #173.
