### PR TITLE
Use golangci-lint for linting

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -5,42 +5,6 @@ if [ -d "wasm/" ]; then
     rm -rf wasm/
 fi
 
-# Install tools to test our code-quality.
-go get -u golang.org/x/lint/golint
-go get -u honnef.co/go/tools/cmd/staticcheck
-
-# Run the static-check tool
-t=$(mktemp)
-staticcheck -checks all ./... > $t
-if [ -s $t ]; then
-    echo "Found errors via 'staticcheck'"
-    cat $t
-    rm $t
-    exit 1
-fi
-rm $t
-
-
-# Run the linter-tool
-echo "Launching linter .."
-golint ./... | grep -v underscores > $t
-if [ -s $t ]; then
-    echo "Found errors via 'staticcheck'"
-    cat $t
-    rm $t
-    exit 1
-fi
-echo "Completed linter .."
-
-
-# At this point failures cause aborts
-set -e
-
-# Run the vet-tool
-echo "Running go vet .."
-go vet ./...
-echo "Completed go vet .."
-
 # Run our golang tests
 go test ./... -race
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,16 @@
 on: pull_request
 name: Pull Request
 jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
   test:
-    name: Run tests
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/evalfilter.go
+++ b/evalfilter.go
@@ -213,7 +213,10 @@ func (e *Eval) Dump() error {
 	fmt.Printf("Bytecode:\n")
 
 	// Use the walker to dump the bytecode.
-	e.machine.WalkBytecode(e.dumper)
+	err := e.machine.WalkBytecode(e.dumper)
+	if err != nil {
+		return err
+	}
 
 	// Show constants, if any are present.
 	consts := e.constants
@@ -238,7 +241,10 @@ func (e *Eval) Dump() error {
 		fmt.Printf(" function %s(%s)\n", name, strings.Join(obj.Arguments, ","))
 
 		// Then dump the body.
-		e.machine.WalkFunctionBytecode(name, e.dumper)
+		err := e.machine.WalkFunctionBytecode(name, e.dumper)
+		if err != nil {
+			return err
+		}
 
 		// Put a newline between functions.
 		if count < len(e.functions)-1 {

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -201,9 +201,12 @@ return( true );
 	}
 
 	// Dump
-	obj.Dump()
+	err := obj.Dump()
+	if err != nil {
+		t.Fatalf("error running Dump:%s\n", err)
+	}
 
-	_, err := obj.Run(nil)
+	_, err = obj.Run(nil)
 	if err != nil {
 		t.Fatalf("unexpected error running code")
 	}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -302,7 +302,7 @@ func (l *Lexer) NextToken() token.Token {
 	default:
 		if isDigit(l.ch) {
 
-			tok := l.readDecimal()
+			tok = l.readDecimal()
 			l.prevToken = tok
 			tok.Column = l.column
 			tok.Line = l.line

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -30,6 +30,11 @@ func New() *Stack {
 	return &Stack{}
 }
 
+// Clear removes all data from the stack
+func (s *Stack) Clear() {
+	s.entries = []object.Object{}
+}
+
 // Empty returns true if the stack is empty.
 func (s *Stack) Empty() bool {
 	return (len(s.entries) == 0)

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -17,6 +17,30 @@ func TestStackStartsEmpty(t *testing.T) {
 	}
 }
 
+// Test we can clear a stack
+func TestClear(t *testing.T) {
+	s := New()
+
+	s.Push(&object.String{Value: "Steve Kemp"})
+	s.Push(&object.String{Value: "Hello, World"})
+	if s.Empty() {
+		t.Errorf("Stack should not be empty after adding item.")
+	}
+	if s.Size() != 2 {
+		t.Errorf("stack has a size-mismatch")
+	}
+
+	// Clear the stack
+	s.Clear()
+
+	if s.Size() != 0 {
+		t.Errorf("stack should be empty after Clear")
+	}
+	if !s.Empty() {
+		t.Errorf("stack should be empty after Clear")
+	}
+}
+
 // Test we can add/remove a value
 func TestStack(t *testing.T) {
 	s := New()

--- a/vm/optimizer.go
+++ b/vm/optimizer.go
@@ -104,7 +104,7 @@ func (vm *VM) optimizeMaths() (bool, error) {
 	//
 	// Walk over the bytecode
 	//
-	vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
+	err := vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
 
 		//
 		// Now we do the magic.
@@ -318,7 +318,9 @@ func (vm *VM) optimizeMaths() (bool, error) {
 		// no error, keep going
 		return true, nil
 	})
-
+	if err != nil {
+		return false, err
+	}
 	//
 	// If we get here we walked all the way over our bytecode
 	// and made zero changes.
@@ -361,7 +363,7 @@ func (vm *VM) optimizeJumps() bool {
 	//
 	// Walk the bytecode.
 	//
-	vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
+	err := vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
 
 		//
 		// Now we do the magic.
@@ -443,6 +445,10 @@ func (vm *VM) optimizeJumps() bool {
 		return true, nil
 	})
 
+	if err != nil {
+		fmt.Printf("optimizeJumps:%s\n", err)
+	}
+
 	//
 	// This function will be invoked until no changes
 	// are made to the bytecode.
@@ -469,7 +475,7 @@ func (vm *VM) removeNOPs() {
 	//
 	// Walk the bytecode.
 	//
-	vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
+	err := vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
 
 		//
 		// Now we do the magic.
@@ -521,6 +527,10 @@ func (vm *VM) removeNOPs() {
 		// No error, keep going
 		return true, nil
 	})
+
+	if err != nil {
+		fmt.Printf("removeNops:%s\n", err)
+	}
 
 	//
 	// We've walked over our code, writing a new jump-table
@@ -622,7 +632,7 @@ func (vm *VM) removeDeadCode() {
 	//
 	// Walk the bytecode.
 	//
-	vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
+	err := vm.WalkBytecode(func(offset int, opCode code.Opcode, opArg interface{}) (bool, error) {
 
 		//
 		// Now we do the magic.
@@ -656,6 +666,10 @@ func (vm *VM) removeDeadCode() {
 		// keep walking
 		return true, nil
 	})
+
+	if err != nil {
+		fmt.Printf("removeDeadCode:%s\n", err)
+	}
 
 	//
 	// Replace the instructions, if we made a sane change

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -206,9 +206,7 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 	// via the addition of the &object.Void{} type.   However we
 	// cannot assume everybody remember to use that.)
 	//
-	for !vm.stack.Empty() {
-		vm.stack.Pop()
-	}
+	vm.stack.Clear()
 
 	//
 	// Instruction pointer and length of bytecode.
@@ -643,7 +641,10 @@ func (vm *VM) Run(obj interface{}) (object.Object, error) {
 
 			// Drop the scope which means function-arguments
 			// are dropped.
-			vm.environment.RemoveScope()
+			err = vm.environment.RemoveScope()
+			if err != nil {
+				return nil, err
+			}
 
 			// reset the state of an object which is to be iterated upon
 		case code.OpIterationReset:
@@ -987,10 +988,10 @@ func (vm *VM) createHash(field reflect.Value) object.Object {
 		k := vm.primitiveToObject(key)
 
 		// The actual thing inside it.
-		field := field.MapIndex(key).Elem()
+		val := field.MapIndex(key).Elem()
 
 		// Get the value.
-		v := vm.primitiveToObject(field)
+		v := vm.primitiveToObject(val)
 
 		pair := object.HashPair{Key: k, Value: v}
 		hashedPairs[k.(object.Hashable).HashKey()] = pair


### PR DESCRIPTION
This pull-request updates our CI process to use the `golangci-lint` tool to lint pull-requests, rather than `staticcheck`, `govet`, etc.

The initial pull-request will fail to run the tests, but later commits will resolve everything which is flagged as an error.

This will close #177.