### PR TITLE
180 join

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In terms of implementation the script to be executed is split into [tokens](toke
 
 Once the bytecode has been generated it can be executed multiple times, there is no state which needs to be maintained, which makes actually executing the script (i.e. running the bytecode) a fast process.
 
-At execution-time the bytecode which was generated is interpreted by a naive [stack-based](stack/stack.go) [virtual machine](vm/vm.go), with some runtime support to provide the [builtin-functions](environment/builtins.go), as well as supporting the addition of host-specific functions.
+At execution-time the bytecode which was generated is interpreted by a naive [stack-based](stack/stack.go) [virtual machine](vm/vm.go), with some runtime support to provide the [built-in functions](environment/builtins.go), as well as supporting the addition of host-specific functions.
 
 The bytecode itself is documented briefly in [BYTECODE.md](BYTECODE.md), but it is not something you should need to understand to use the library, only if you're interested in debugging a misbehaving script.
 
@@ -98,6 +98,8 @@ You can also easily add new primitives to the engine, by defining a function in 
 * `int(value)`
   * Tries to convert the value to an integer, returns Null on failure.
   * e.g. `int("3")`.
+* `join(array,deliminator)`
+  * Return a string consisting of the array elements joined by the given string.
 * `keys`
   * Returns the available keys in the specified hash, in sorted order.
 * `len(field | value)`

--- a/environment/builtins.go
+++ b/environment/builtins.go
@@ -126,6 +126,37 @@ func fnInt(args []object.Object) object.Object {
 	return &object.Integer{Value: i}
 }
 
+
+// Join the given array with a string.
+func fnJoin(args []object.Object) object.Object {
+
+	// We expect two arguments
+	if len(args) != 2 {
+		return &object.Null{}
+	}
+
+	// The first argument must be an array
+	if args[0].Type() != object.ARRAY {
+		return &object.Null{}
+	}
+	if args[1].Type() != object.STRING {
+		return &object.Null{}
+	}
+
+	// Do the join
+	out := ""
+	len := len(args[0].(*object.Array).Elements)
+
+	for i, entry := range(args[0].(*object.Array).Elements) {
+		out += entry.Inspect()
+		if i != len-1 {
+			out += args[1].(*object.String).Value
+	        }
+	}
+
+	return &object.String{Value: out}
+}
+
 // Get the (sorted) keys from the specified hash.
 func fnKeys(args []object.Object) object.Object {
 

--- a/environment/builtins_test.go
+++ b/environment/builtins_test.go
@@ -1185,3 +1185,61 @@ func TestReverseSort(t *testing.T) {
 	}
 
 }
+
+func TestJoin(t *testing.T) {
+
+	// Two arguments are required
+	var args []object.Object
+	out := fnJoin(args)
+	if out.Type() != object.NULL {
+		t.Errorf("no arguments returns a weird result")
+	}
+
+	// 1 arg
+	args = append(args, &object.Null{})
+	out = fnJoin(args)
+	if out.Type() != object.NULL {
+		t.Errorf("one argument returns a weird result")
+	}
+
+	// 2 args - but wrong types
+	args = append(args, &object.Null{})
+	out = fnJoin(args)
+	if out.Type() != object.NULL {
+		t.Errorf("one argument returns a weird result")
+	}
+
+	// 2 args - wrong types, again
+	args = []object.Object{
+		// Array
+		&object.Array{ Elements:
+			[]object.Object{
+				&object.String{Value: "Steve"},
+				&object.String{Value: "Kemp"},
+			},
+		},
+		&object.Boolean{Value: false}}
+	out = fnJoin(args)
+	if out.Type() != object.NULL {
+		t.Errorf("one argument returns a weird result")
+	}
+
+	// Valid
+	args = []object.Object{
+		// Array
+		&object.Array{ Elements:
+			[]object.Object{
+				&object.String{Value: "Steve"},
+				&object.String{Value: "Kemp"},
+			},
+		},
+		&object.String{Value: "-"}}
+
+	out = fnJoin(args)
+	if out.Type() != object.STRING {
+		t.Errorf("didn't get a string back with a valid join")
+	}
+	if out.Inspect() != "Steve-Kemp" {
+		t.Errorf("wrong result for join: %s != Steve-Kemp", out.Inspect())
+	}
+}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -68,6 +68,7 @@ func New() *Environment {
 	env.SetFunction("float", fnFloat)
 	env.SetFunction("getenv", fnGetenv)
 	env.SetFunction("int", fnInt)
+	env.SetFunction("join", fnJoin)
 	env.SetFunction("keys", fnKeys)
 	env.SetFunction("len", fnLen)
 	env.SetFunction("lower", fnLower)

--- a/evalfilter_test.go
+++ b/evalfilter_test.go
@@ -1521,3 +1521,38 @@ func TestNullJsonField(t *testing.T) {
 		}
 	}
 }
+
+func TestSplitJoin(t *testing.T) {
+	input := `
+tmp = "XXX";
+out = join( split( tmp, " " ), "-" );
+
+return out ;
+`
+	// The value we'll search/replace on
+	name := "This is a file name with spaces / stuff.docx"
+
+	// Replace the string in our template-program
+	input = strings.ReplaceAll(input, "XXX", name )
+
+	// The expected output will be name =~ s/ /-/g
+	nameOut := strings.ReplaceAll(name, " ", "-");
+
+	// parse/prepare
+	obj := New(input)
+	err := obj.Prepare()
+	if err != nil {
+		t.Fatalf("Failed to compile: %s",err)
+	}
+
+	// execute
+	out, err2 := obj.Execute(nil)
+	if err2 != nil {
+		t.Fatalf("unexpected error:%s", err2)
+	}
+
+	// confirm
+	if out.Inspect() != nameOut {
+		t.Fatalf("failed split/join test got %s not %s", out.Inspect(), nameOut)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -687,11 +687,6 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 // parseIfCondition parses an if-expression.
 func (p *Parser) parseIfExpression() ast.Expression {
 	expression := &ast.IfExpression{Token: p.curToken}
-	if expression == nil {
-		msg := fmt.Sprintf("unexpected nil expression around %s", p.curToken.Position())
-		p.errors = append(p.errors, msg)
-		return nil
-	}
 
 	// Look for the condition, surrounded by "(" + ")".
 	expression.Condition = p.parseBracketExpression()
@@ -889,11 +884,7 @@ func (p *Parser) parseFunctionParameters() []*ast.Identifier {
 // parseWhileStatement parses a while-statement.
 func (p *Parser) parseWhileStatement() ast.Expression {
 	expression := &ast.WhileStatement{Token: p.curToken}
-	if expression == nil {
-		msg := fmt.Sprintf("unexpected nil expression around %s", p.curToken.Position())
-		p.errors = append(p.errors, msg)
-		return nil
-	}
+
 	if !p.expectPeek(token.LPAREN) {
 		msg := fmt.Sprintf("expected ( but got %s around %s", p.curToken.Literal, p.curToken.Position())
 		p.errors = append(p.errors, msg)


### PR DESCRIPTION
This pull-request updates #180, to allow the use of a new built-in function `join`.

This works with `split` to allow simple search/replace to be performed, albeit in a suboptimal fashion.  

I intend to allow _real_ search/replace operations, but having `split` without `join` feels like an omission that should be resolved regardless.